### PR TITLE
Remove ignore command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -36,8 +36,6 @@ pub enum Command {
 
     Check(CheckCmd),
 
-    Ignore(IgnoreCmd),
-
     Init,
 }
 
@@ -118,19 +116,4 @@ impl Display for MaxProblems {
             Self::Limited(l) => l.fmt(f),
         }
     }
-}
-
-#[derive(Clone, Debug, clap::Args)]
-pub struct IgnoreCmd {
-    pub kind: IgnoreKind,
-
-    #[arg(required = true)]
-    pub to_ignore: Vec<String>,
-}
-
-#[derive(Clone, Debug, PartialEq, clap::ValueEnum)]
-pub enum IgnoreKind {
-    Extension,
-    Language,
-    Dir,
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -7,7 +7,6 @@ use std::env;
 use std::fs::File;
 use std::io::{BufWriter, ErrorKind, Read, Write};
 use std::ops::Deref;
-use toml_edit::Document;
 
 use crate::error::Error;
 
@@ -85,12 +84,6 @@ impl Manifest {
         let mut writer = BufWriter::new(file);
         writer.write_all(Self::DEFAULT_CONTENT.as_bytes())?;
         Ok(())
-    }
-
-    fn acquire_document() -> anyhow::Result<(Utf8PathBuf, Document)> {
-        let (project_root, raw_data) = Self::acquire_file()?;
-        let document = raw_data.parse()?;
-        Ok((project_root, document))
     }
 
     fn acquire_file() -> anyhow::Result<(Utf8PathBuf, String)> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,13 +26,6 @@ pub enum Error {
     //
     // #[error("{0} declares no trigger")]
     // NoTrigger(Id),
-    #[error("invalid toml type: expected {expected} but got {actual}")]
-    TomlTypeError {
-        name: String,
-        expected: &'static str,
-        actual: &'static str,
-    },
-
     #[error("{attr} is unavailable during {stage_name}")]
     Unavailable {
         attr: AttrName,

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,9 +17,8 @@ use std::{env, fs, process::ExitCode};
 
 use camino::Utf8PathBuf;
 use clap::Parser as _;
-use cli::{CheckCmd, IgnoreCmd, IgnoreKind};
+use cli::CheckCmd;
 use context::{Context, Manifest};
-use error::Error;
 use log::{info, log_enabled, trace};
 use source_file::SourceFile;
 use strum::IntoEnumIterator;
@@ -42,7 +41,6 @@ async fn main() -> anyhow::Result<ExitCode> {
         Command::ListLanguages => list_languages(),
         Command::ListLints => list_lints().await,
         Command::Check(cmd_args) => check(cmd_args),
-        Command::Ignore(cmd_args) => ignore(cmd_args),
         Command::Init => init(),
     }?;
 
@@ -201,23 +199,6 @@ fn walkdir(
     }
 
     Ok(())
-}
-
-fn ignore(cmd_args: IgnoreCmd) -> anyhow::Result<()> {
-    if cmd_args.kind == IgnoreKind::Language {
-        let unknown_languages: Vec<_> = cmd_args
-            .to_ignore
-            .iter()
-            .filter(|lang_name| {
-                SupportedLanguage::iter().all(|sup_lang| sup_lang.name() != *lang_name)
-            })
-            .map(ToOwned::to_owned)
-            .collect();
-        if let Some(unknown) = unknown_languages.first() {
-            return Err(Error::UnknownLanguage(unknown.to_string()).into());
-        }
-    }
-    Manifest::ignore(cmd_args.kind, cmd_args.to_ignore)
 }
 
 fn init() -> anyhow::Result<()> {


### PR DESCRIPTION
This command is redundant and plays poorly with shell expansion. Users can just edit the manifest
