### PR TITLE
Allow Starlark to iterate, index and slice over path components

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1536,6 +1536,7 @@ dependencies = [
  "glob",
  "indoc",
  "joinery",
+ "lazy_static",
  "log",
  "num-traits",
  "pretty_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ enum-map = "2.7.3"
 glob = "0.3.1"
 indoc = "2.0.4"
 joinery = "3.1.0"
+lazy_static = "1.4.0"
 log = { version = "0.4.20", features = ["std", "kv_unstable"] }
 num-traits = "0.2.17"
 serde = { version = "1.0.193", features = ["derive"] }

--- a/src/scriptlets.rs
+++ b/src/scriptlets.rs
@@ -9,3 +9,6 @@ mod store;
 
 pub use observers::{Observer, ScriptletObserverData};
 pub use store::{PreinitingStore, VexingStore};
+
+#[cfg(test)]
+pub use print_handler::PrintHandler;

--- a/src/scriptlets/event.rs
+++ b/src/scriptlets/event.rs
@@ -235,17 +235,19 @@ mod test {
             .with_scriptlet(
                 "vexes/test.star",
                 formatdoc! {r#"
-                    load('check.star', 'check')
+                        load('{check_path}', 'check')
 
-                    def init():
-                        vex.language('rust')
-                        vex.query('(binary_expression) @bin_expr')
-                        vex.observe('match', lambda x: x) # Make the error checker happy.
-                        vex.observe('{event_name}', on_{event_name})
+                        def init():
+                            vex.language('rust')
+                            vex.query('(binary_expression) @bin_expr')
+                            vex.observe('match', lambda x: x) # Make the error checker happy.
+                            vex.observe('{event_name}', on_{event_name})
 
-                    def on_{event_name}(event):
-                        fail('error-marker')
-                "#},
+                        def on_{event_name}(event):
+                            fail('error-marker')
+                    "#,
+                    check_path = VexTest::CHECK_STARLARK_PATH,
+                },
             )
             .with_source_file(
                 "src/main.rs",
@@ -261,40 +263,42 @@ mod test {
             .with_scriptlet(
                 "vexes/test.star",
                 formatdoc! {r#"
-                    load('check.star', 'check')
+                        load('{check_path}', 'check')
 
-                    def init():
-                        vex.language('rust')
-                        vex.query('(binary_expression) @bin_expr')
-                        vex.observe('match', lambda x: x) # Make the error checker happy.
-                        vex.observe('{event_name}', on_{event_name})
+                        def init():
+                            vex.language('rust')
+                            vex.query('(binary_expression) @bin_expr')
+                            vex.observe('match', lambda x: x) # Make the error checker happy.
+                            vex.observe('{event_name}', on_{event_name})
 
-                    def on_{event_name}(event):
-                        check['eq'](type(event), '{type_name}')
-                "#},
+                        def on_{event_name}(event):
+                            check['eq'](type(event), '{type_name}')
+                    "#,
+                    check_path = VexTest::CHECK_STARLARK_PATH,
+                },
             )
             .assert_irritation_free();
         VexTest::new("common-attrs")
             .with_scriptlet(
                 "vexes/test.star",
                 formatdoc! {r#"
-                    load('check.star', 'check')
+                        load('{check_path}', 'check')
 
-                    def init():
-                        vex.language('rust')
-                        vex.query('(binary_expression) @bin_expr')
-                        vex.observe('match', lambda x: x) # Make the error checker happy.
-                        vex.observe('{event_name}', on_{event_name})
+                        def init():
+                            vex.language('rust')
+                            vex.query('(binary_expression) @bin_expr')
+                            vex.observe('match', lambda x: x) # Make the error checker happy.
+                            vex.observe('{event_name}', on_{event_name})
 
-                    def on_{event_name}(event):
-                        check['hasattr'](event, 'path')
-                        if 'project' in '{event_name}':
-                            check['is_path'](str(event.path))
-                        else:
-                            expected = ['src/main.rs', 'src\\main.rs']
-                            if str(event.path) not in expected:
-                                fail('assertion failed: got path %r but expected one of %r' % (event.path, ', '.join(expected)))
-                "#},
+                        def on_{event_name}(event):
+                            check['hasattr'](event, 'path')
+                            if 'project' in '{event_name}':
+                                check['is_path'](str(event.path))
+                            else:
+                                check['in'](str(event.path), ['src/main.rs', 'src\\main.rs'])
+                    "#,
+                    check_path = VexTest::CHECK_STARLARK_PATH,
+                },
             )
             .with_source_file(
                 "src/main.rs",

--- a/src/source_path.rs
+++ b/src/source_path.rs
@@ -192,7 +192,7 @@ impl<'v> StarlarkValue<'v> for PrettyPath {
         let stop = stop.and_then(Value::unpack_i32);
         let stride = stride.and_then(Value::unpack_i32).unwrap_or(1);
         if stride == 0 {
-            todo!("reject me!");
+            return Err(ValueError::IndexOutOfBound(stride).into());
         }
 
         if stride > 0 {
@@ -473,6 +473,17 @@ mod test {
                 if len(errs):
                     print('encountered %d problems' % len(errs))
                     fail('come take a lookie, lookie... come take a lookie here')
-            "#})
+            "#});
+        {
+            let expected = "Index `0` is out of bound";
+            let err = PathTest::new("zero-stride")
+                .path("src/foo/bar/baz/main.rs")
+                .try_run("path[::0]")
+                .unwrap_err();
+            assert!(
+                err.to_string().contains(expected),
+                "unexpected error: expected {expected:?} but got {err}"
+            );
+        }
     }
 }

--- a/src/source_path.rs
+++ b/src/source_path.rs
@@ -437,8 +437,8 @@ mod test {
                 errs = []
                 def eq(start, stop, stride, a, b):
                     if a != b:
-                        errs.append(('?? [%r:%r:%r]' % (start, stop, stride), a, b))
-                        print('!! %r, %r, %r' % (start, stop, stride), a, b)
+                        errs.append(('[%r:%r:%r]' % (start, stop, stride), a, b))
+                        print('%r, %r, %r' % (start, stop, stride), a, b)
                 def test(start, stop, stride):
                     if stride == 0:
                         return
@@ -471,8 +471,7 @@ mod test {
                 for err in errs:
                     print(*err)
                 if len(errs):
-                    print('encountered %d problems' % len(errs))
-                    fail('come take a lookie, lookie... come take a lookie here')
+                    fail('encountered %d problems' % len(errs))
             "#});
         {
             let expected = "Index `0` is out of bound";

--- a/src/source_path.rs
+++ b/src/source_path.rs
@@ -199,6 +199,10 @@ impl<'v> StarlarkValue<'v> for PrettyPath {
             let normalise_index = |idx: i32| if idx < 0 { idx + n } else { idx }.clamp(0, n);
             let low = start.map(normalise_index).unwrap_or(0);
             let high = stop.map(normalise_index).unwrap_or(n);
+            if high <= low {
+                // Empty result fast path.
+                return Ok(heap.alloc(AllocList::<[i32; 0]>([])));
+            }
             Ok(heap.alloc(AllocList(
                 self.components()
                     .enumerate()
@@ -213,9 +217,9 @@ impl<'v> StarlarkValue<'v> for PrettyPath {
             let high = start.map(normalise_index).unwrap_or(n - 1);
             let low = stop.map(normalise_index).unwrap_or(-1);
             if high <= low {
+                // Empty result fast path.
                 return Ok(heap.alloc(AllocList::<[i32; 0]>([])));
             }
-
             Ok(heap.alloc(AllocList(
                 self.components()
                     .rev()

--- a/src/source_path.rs
+++ b/src/source_path.rs
@@ -86,8 +86,8 @@ impl PrettyPath {
             }
 
             if let Some(other) = other.unpack_str() {
-                let str = this.0.as_str();
-                return Ok(str == other || str.replace('/', "\\") == other);
+                let this_str = this.0.as_str();
+                return Ok(this_str == other || this_str.replace('/', "\\") == other);
             }
 
             Ok(false)

--- a/src/source_path.rs
+++ b/src/source_path.rs
@@ -3,7 +3,11 @@ use std::{fmt::Display, ops::Deref, sync::Arc};
 use allocative::Allocative;
 use camino::Utf8Path;
 use dupe::Dupe;
-use starlark::{starlark_simple_value, values::StarlarkValue};
+use starlark::{
+    environment::{Methods, MethodsBuilder, MethodsStatic},
+    starlark_module, starlark_simple_value,
+    values::{list::AllocList, Demand, Heap, StarlarkValue, Value, ValueError},
+};
 use starlark_derive::{starlark_value, NoSerialize, ProvidesStaticType};
 
 #[derive(Clone, Debug, Dupe)]
@@ -65,6 +69,30 @@ impl PrettyPath {
     pub fn as_str(&self) -> &str {
         self.0.as_str()
     }
+
+    pub fn len(&self) -> usize {
+        self.0.components().count()
+    }
+
+    #[starlark_module]
+    fn methods(builder: &mut MethodsBuilder) {
+        fn matches<'v>(this: Value<'v>, other: Value<'v>) -> anyhow::Result<bool> {
+            let this = this
+                .request_value::<&PrettyPath>()
+                .expect("receiver has incorrect type");
+
+            if let Some(other) = other.request_value::<&PrettyPath>() {
+                return Ok(this == other);
+            }
+
+            if let Some(other) = other.unpack_str() {
+                let str = this.0.as_str();
+                return Ok(str == other || str.replace('/', "\\") == other);
+            }
+
+            Ok(false)
+        }
+    }
 }
 
 impl From<&str> for PrettyPath {
@@ -94,5 +122,356 @@ impl Display for PrettyPath {
 }
 
 #[starlark_value(type = "Path")]
-impl<'v> StarlarkValue<'v> for PrettyPath {} // TODO(kcza): override Eq to be more lenient to
-                                             // string comparisons!
+impl<'v> StarlarkValue<'v> for PrettyPath {
+    fn provide(&'v self, demand: &mut Demand<'_, 'v>) {
+        demand.provide_value(self)
+    }
+
+    fn get_methods() -> Option<&'static Methods> {
+        static RES: MethodsStatic = MethodsStatic::new();
+        RES.methods(PrettyPath::methods)
+    }
+
+    fn equals(&self, other: Value<'v>) -> anyhow::Result<bool> {
+        Ok(other
+            .request_value::<&Self>()
+            .map(|other| self == other)
+            .unwrap_or_default())
+    }
+
+    fn length(&self) -> anyhow::Result<i32> {
+        Ok(self.len() as i32)
+    }
+
+    fn is_in(&self, other: Value<'v>) -> anyhow::Result<bool> {
+        let Some(str) = other.unpack_str() else {
+            return Err(ValueError::IncorrectParameterTypeWithExpected(
+                "str".to_owned(),
+                other.get_type().to_owned(),
+            )
+            .into());
+        };
+        Ok(self.components().any(|c| c.as_str() == str))
+    }
+
+    fn iterate_collect(&self, heap: &'v Heap) -> anyhow::Result<Vec<Value<'v>>> {
+        Ok(self.components().map(|c| heap.alloc(c.as_str())).collect())
+    }
+
+    fn at(&self, index: Value<'v>, heap: &'v Heap) -> anyhow::Result<Value<'v>> {
+        let Some(mut index) = index.unpack_i32() else {
+            return ValueError::unsupported_with(self, "[]", index);
+        };
+        let n = self.len() as i32;
+        if index >= n || index < -n {
+            return Err(ValueError::IndexOutOfBound(index).into());
+        }
+        if index < 0 {
+            index += n;
+        }
+        let component = {
+            if index >= 0 {
+                self.components().nth(index as usize)
+            } else {
+                self.components().nth_back((-1 - index) as usize)
+            }
+            .expect("index computation incorrect")
+        };
+        Ok(heap.alloc(component.as_str()))
+    }
+
+    fn slice(
+        &self,
+        start: Option<Value<'v>>,
+        stop: Option<Value<'v>>,
+        stride: Option<Value<'v>>,
+        heap: &'v Heap,
+    ) -> anyhow::Result<Value<'v>> {
+        let n = self.len() as i32;
+        let start = start.and_then(Value::unpack_i32);
+        let stop = stop.and_then(Value::unpack_i32);
+        let stride = stride.and_then(Value::unpack_i32).unwrap_or(1);
+        if stride == 0 {
+            todo!("reject me!");
+        }
+
+        if stride > 0 {
+            let normalise_index = |idx: i32| if idx < 0 { idx + n } else { idx }.clamp(0, n);
+            let low = start.map(normalise_index).unwrap_or(0);
+            let high = stop.map(normalise_index).unwrap_or(n);
+            Ok(heap.alloc(AllocList(
+                self.components()
+                    .enumerate()
+                    .map(|(i, c)| (i as i32, c))
+                    .skip_while(|(i, _)| *i < low)
+                    .take_while(|(i, _)| *i < high)
+                    .filter(|(i, _)| (i - low) % stride == 0)
+                    .map(|(_, c)| c.as_str()),
+            )))
+        } else {
+            let normalise_index = |idx: i32| if idx < 0 { idx + n } else { idx }.clamp(-1, n - 1);
+            let high = start.map(normalise_index).unwrap_or(n - 1);
+            let low = stop.map(normalise_index).unwrap_or(-1);
+            if high <= low {
+                return Ok(heap.alloc(AllocList::<[i32; 0]>([])));
+            }
+
+            Ok(heap.alloc(AllocList(
+                self.components()
+                    .rev()
+                    .enumerate()
+                    .map(|(i, c)| (n - i as i32 - 1, c))
+                    .skip_while(|(i, _)| *i > high)
+                    .take_while(|(i, _)| *i > low)
+                    .filter(|(i, _)| (*i - high) % -stride == 0)
+                    .map(|(_, c)| c.as_str()),
+            )))
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use indoc::{formatdoc, indoc};
+    use lazy_static::lazy_static;
+    use regex::Regex;
+    use starlark::{
+        environment::{FrozenModule, Globals, GlobalsBuilder, LibraryExtension, Module},
+        eval::{Evaluator, FileLoader},
+        syntax::{AstModule, Dialect},
+    };
+
+    use crate::{error::Error, scriptlets::PrintHandler, vextest::VexTest};
+
+    use super::*;
+
+    struct PathTest<'s> {
+        name: &'s str,
+        path: Option<&'s str>,
+    }
+
+    impl<'s> PathTest<'s> {
+        fn new(name: &'s str) -> Self {
+            Self { name, path: None }
+        }
+
+        fn path(mut self, path: &'s str) -> Self {
+            self.path = Some(path);
+            self
+        }
+
+        fn run(self, to_run: impl AsRef<str>) {
+            self.try_run(to_run).unwrap()
+        }
+
+        fn try_run(self, to_run: impl AsRef<str>) -> anyhow::Result<()> {
+            self.setup();
+
+            let path = PrettyPath::new(Utf8Path::new(self.path.expect("path not set")));
+            let module = Module::new();
+            module.set("path", module.heap().alloc(path));
+
+            let code = formatdoc! {r#"
+                    load('{check_path}', 'check')
+                    {to_run}
+                "#,
+                check_path = VexTest::CHECK_STARLARK_PATH,
+                to_run = to_run.as_ref(),
+            };
+            let dialect = Dialect {
+                enable_top_level_stmt: true,
+                ..Dialect::Standard
+            };
+            let ast = AstModule::parse("vexes/test.star", code.to_string(), &dialect).unwrap();
+            let print_handler = PrintHandler::new("test");
+            let mut eval = Evaluator::new(&module);
+            eval.set_print_handler(&print_handler);
+            eval.set_loader(&TestModuleCache);
+            eval.eval_module(ast, &Self::globals()).map(|_| ())
+        }
+
+        fn globals() -> Globals {
+            GlobalsBuilder::extended_by(&[LibraryExtension::Print]).build()
+        }
+
+        fn setup(&self) {
+            eprintln!("running test {}...", self.name);
+        }
+    }
+
+    struct TestModuleCache;
+
+    impl FileLoader for TestModuleCache {
+        fn load(&self, path: &str) -> anyhow::Result<starlark::environment::FrozenModule> {
+            if path != VexTest::CHECK_STARLARK_PATH {
+                let path = PrettyPath::from(path);
+                return Err(Error::NoSuchModule(path).into());
+            }
+            lazy_static! {
+                static ref CHECK_MODULE: FrozenModule = {
+                    let module = Module::new();
+                    {
+                        let mut eval = Evaluator::new(&module);
+                        let ast = AstModule::parse(
+                            VexTest::CHECK_STARLARK_PATH,
+                            VexTest::CHECK_SRC.to_string(),
+                            &Dialect::Standard,
+                        )
+                        .unwrap();
+                        eval.eval_module(ast, &Globals::standard()).unwrap();
+                    }
+                    module.freeze().unwrap()
+                };
+            }
+            Ok(CHECK_MODULE.deref().dupe())
+        }
+    }
+
+    #[test]
+    fn equals() {
+        PathTest::new("equals").path("src/main.rs").run(indoc! {r#"
+            check['eq'](path, path)
+            check['neq'](path, '')
+            check['neq']('', path)
+        "#});
+    }
+
+    #[test]
+    fn matches() {
+        PathTest::new("matches").path("src/main.rs").run(indoc! {r#"
+            check['true'](path.matches("src/main.rs"))
+            check['true'](path.matches("src\\main.rs"))
+            check['false'](path.matches(None))
+            check['false'](path.matches(''))
+            check['false'](path.matches("src/lib.rs"))
+            check['false'](path.matches("src\\lib.rs"))
+        "#});
+    }
+
+    #[test]
+    fn len() {
+        PathTest::new("absolute-unix")
+            .path("/")
+            .run("check['eq'](len(path), 1)");
+        PathTest::new("absolute-windows")
+            .path("A:")
+            .run("check['eq'](len(path), 1)");
+        PathTest::new("normal-unix")
+            .path("src/main.rs")
+            .run("check['eq'](len(path), 2)");
+    }
+
+    #[test]
+    fn r#in() {
+        PathTest::new("in").path("src/main.rs").run(indoc! {r#"
+            check['in']('src', path)
+            check['in']('main.rs', path)
+        "#})
+    }
+
+    #[test]
+    fn iterate() {
+        PathTest::new("iter").path("src/main.rs").run(indoc! {r#"
+            for (part, expected) in zip(path, ['src', 'main.rs']):
+                check['eq'](part, expected)
+        "#})
+    }
+
+    #[test]
+    fn at() {
+        {
+            let expected = "Index `0` is out of bound";
+            let err = PathTest::new("empty")
+                .path("")
+                .try_run("path[0]")
+                .unwrap_err();
+            assert!(
+                err.to_string().contains(expected),
+                "unexpected error: expected {expected:?} but got {err}"
+            )
+        }
+
+        {
+            const PATH: &'static str = "src/foo/bar/baz/main.rs";
+            let n = 1 + PATH.chars().filter(|c| *c == '/').count() as i64;
+            for index in (-2 * n..-n).chain(n..2 * n) {
+                let expected = Regex::new("Index `-?[0-9]+` is out of bound").unwrap();
+                let err = PathTest::new("out-of-bounds")
+                    .path(PATH)
+                    .try_run(format!("path[{index}]"))
+                    .unwrap_err();
+                assert!(
+                    expected.is_match(&err.to_string()),
+                    "unexpected error: expected {expected:?} but got {err}"
+                )
+            }
+        }
+
+        PathTest::new("populated")
+            .path("src/foo/bar/baz/main.rs")
+            .run(indoc! {r#"
+                expected = ['src', 'foo', 'bar', 'baz', 'main.rs']
+                n = len(expected)
+                for i in range(-n, n - 1):
+                    check['eq'](path[i], expected[i])
+            "#})
+    }
+
+    #[test]
+    fn slice() {
+        PathTest::new("ok-indices")
+            .path("src/foo/bar/baz/main.rs")
+            .run(indoc! {r#"
+                expected = ['src', 'foo', 'bar', 'baz', 'main.rs']
+
+                def gen_test_indices(expected, min=2*len(expected), max=2*len(expected)):
+                    ret = [None]
+                    ret.extend(range(min, max+1))
+                    return ret
+                starts = gen_test_indices(expected)
+                stops = gen_test_indices(expected)
+                strides = gen_test_indices(expected)
+                tests = [(start, stop, stride) for start in starts for stop in stops for stride in strides]
+
+                errs = []
+                def eq(start, stop, stride, a, b):
+                    if a != b:
+                        errs.append(('?? [%r:%r:%r]' % (start, stop, stride), a, b))
+                        print('!! %r, %r, %r' % (start, stop, stride), a, b)
+                def test(start, stop, stride):
+                    if stride == 0:
+                        return
+
+                    if start != None:
+                        if stop != None:
+                            if stride != None:
+                                eq(start, stop, stride, path[start:stop:stride], expected[start:stop:stride])
+                            else:
+                                eq(start, stop, stride, path[start:stop:], expected[start:stop:])
+                        else:
+                            if stride != None:
+                                eq(start, stop, stride, path[start::stride], expected[start::stride])
+                            else:
+                                eq(start, stop, stride, path[start::], expected[start::])
+                    else:
+                        if stop != None:
+                            if stride != None:
+                                eq(start, stop, stride, path[:stop:stride], expected[:stop:stride])
+                            else:
+                                eq(start, stop, stride, path[:stop:], expected[:stop:])
+                        else:
+                            if stride != None:
+                                eq(start, stop, stride, path[::stride], expected[::stride])
+                            else:
+                                eq(start, stop, stride, path[::], expected[::])
+
+                for (start, stop, stride) in tests:
+                    test(start, stop, stride)
+                for err in errs:
+                    print(*err)
+                if len(errs):
+                    print('encountered %d problems' % len(errs))
+                    fail('come take a lookie, lookie... come take a lookie here')
+            "#})
+    }
+}

--- a/src/source_path.rs
+++ b/src/source_path.rs
@@ -329,10 +329,11 @@ mod test {
 
     #[test]
     fn equals() {
-        PathTest::new("equals").path("src/main.rs").run(indoc! {r#"
+        let path = "src/main.rs";
+        PathTest::new("equals").path(path).run(formatdoc! {r#"
             check['eq'](path, path)
-            check['neq'](path, '')
-            check['neq']('', path)
+            check['neq'](path, '{path}')
+            check['neq']('{path}', path)
         "#});
     }
 
@@ -392,7 +393,7 @@ mod test {
         }
 
         {
-            const PATH: &'static str = "src/foo/bar/baz/main.rs";
+            const PATH: &str = "src/foo/bar/baz/main.rs";
             let n = 1 + PATH.chars().filter(|c| *c == '/').count() as i64;
             for index in (-2 * n..-n).chain(n..2 * n) {
                 let expected = Regex::new("Index `-?[0-9]+` is out of bound").unwrap();


### PR DESCRIPTION
This PR improves Starlark-side `PrettyPath` handling, allowing the user to add logic depending on path components. In particular, this avoids fragile code which may incorrectly assume unix-style or windows-style path separators.
