### PR TITLE
Add `dump` subcommand

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -152,30 +152,30 @@ mod test {
 
     #[test]
     fn no_default() {
-        Args::try_parse_from(&["vex"]).unwrap_err();
+        Args::try_parse_from(["vex"]).unwrap_err();
     }
 
     #[test]
     fn verbosity_level() {
         const CMD: &str = "check";
         assert_eq!(
-            Args::try_parse_from(&["vex", CMD]).unwrap().verbosity_level,
+            Args::try_parse_from(["vex", CMD]).unwrap().verbosity_level,
             0
         );
         assert_eq!(
-            Args::try_parse_from(&["vex", "-v", CMD])
+            Args::try_parse_from(["vex", "-v", CMD])
                 .unwrap()
                 .verbosity_level,
             1
         );
         assert_eq!(
-            Args::try_parse_from(&["vex", "-vv", CMD])
+            Args::try_parse_from(["vex", "-vv", CMD])
                 .unwrap()
                 .verbosity_level,
             2
         );
         assert_eq!(
-            Args::try_parse_from(&["vex", "-vv", CMD])
+            Args::try_parse_from(["vex", "-vv", CMD])
                 .unwrap()
                 .verbosity_level,
             2
@@ -185,7 +185,7 @@ mod test {
     #[test]
     fn list_languages() {
         assert_eq!(
-            Args::try_parse_from(&["vex", "languages"])
+            Args::try_parse_from(["vex", "languages"])
                 .unwrap()
                 .into_command(),
             Command::ListLanguages,
@@ -195,7 +195,7 @@ mod test {
     #[test]
     fn list_lints() {
         assert_eq!(
-            Args::try_parse_from(&["vex", "lints"])
+            Args::try_parse_from(["vex", "lints"])
                 .unwrap()
                 .into_command(),
             Command::ListLints,
@@ -207,7 +207,7 @@ mod test {
 
         #[test]
         fn default() {
-            let args = Args::try_parse_from(&["vex", "check"]).unwrap();
+            let args = Args::try_parse_from(["vex", "check"]).unwrap();
             let cmd = args.into_command();
             assert!(matches!(cmd, Command::Check(_)));
 
@@ -217,7 +217,7 @@ mod test {
 
         #[test]
         fn finite_max_problems() {
-            let args = Args::try_parse_from(&["vex", "check", "--max-problems", "1000"]).unwrap();
+            let args = Args::try_parse_from(["vex", "check", "--max-problems", "1000"]).unwrap();
             let cmd = args.into_command();
             assert!(matches!(cmd, Command::Check(_)));
 
@@ -228,7 +228,7 @@ mod test {
         #[test]
         fn infinite_max_problems() {
             let args =
-                Args::try_parse_from(&["vex", "check", "--max-problems", "unlimited"]).unwrap();
+                Args::try_parse_from(["vex", "check", "--max-problems", "unlimited"]).unwrap();
             let cmd = args.into_command();
             assert!(matches!(cmd, Command::Check(_)));
 
@@ -242,13 +242,13 @@ mod test {
 
         #[test]
         fn requires_path() {
-            Args::try_parse_from(&["vex", "dump"]).unwrap_err();
+            Args::try_parse_from(["vex", "dump"]).unwrap_err();
         }
 
         #[test]
         fn relative_path() {
             const PATH: &str = "./src/main.rs";
-            let args = Args::try_parse_from(&["vex", "dump", PATH]).unwrap();
+            let args = Args::try_parse_from(["vex", "dump", PATH]).unwrap();
             let dump_cmd = args.into_command().into_dump_cmd().unwrap();
             assert_eq!(dump_cmd.path, PATH);
         }
@@ -256,7 +256,7 @@ mod test {
         #[test]
         fn absolute_path() {
             const PATH: &str = "/src/main.rs";
-            let args = Args::try_parse_from(&["vex", "dump", PATH]).unwrap();
+            let args = Args::try_parse_from(["vex", "dump", PATH]).unwrap();
             let dump_cmd = args.into_command().into_dump_cmd().unwrap();
             assert_eq!(dump_cmd.path, PATH);
         }
@@ -265,7 +265,7 @@ mod test {
     #[test]
     fn init() {
         assert_eq!(
-            Args::try_parse_from(&["vex", "init"])
+            Args::try_parse_from(["vex", "init"])
                 .unwrap()
                 .into_command(),
             Command::Init,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,6 @@
 use std::fmt::Display;
 
+use camino::Utf8PathBuf;
 use clap::{
     builder::{StringValueParser, TypedValueParser},
     ArgAction, Parser, Subcommand,
@@ -35,6 +36,8 @@ pub enum Command {
     ListLints,
 
     Check(CheckCmd),
+
+    Dump(DumpCmd),
 
     Init,
 }
@@ -116,4 +119,9 @@ impl Display for MaxProblems {
             Self::Limited(l) => l.fmt(f),
         }
     }
+}
+
+#[derive(Debug, Default, Parser)]
+pub struct DumpCmd {
+    pub path: Utf8PathBuf,
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -11,7 +11,8 @@ use std::{
     fs::{self, File},
 };
 
-use crate::error::Error;
+use crate::error::{Error, IOAction};
+use crate::result::Result;
 use crate::source_path::PrettyPath;
 
 #[derive(Debug)]
@@ -21,7 +22,7 @@ pub struct Context {
 }
 
 impl Context {
-    pub fn acquire() -> anyhow::Result<Self> {
+    pub fn acquire() -> Result<Self> {
         let (project_root, raw_data) = Manifest::acquire_file()?;
         let project_root = PrettyPath::new(&project_root);
         let data = toml_edit::de::from_str(&raw_data)?;
@@ -32,7 +33,7 @@ impl Context {
     }
 
     #[cfg(test)]
-    pub fn acquire_in(dir: &Utf8Path) -> anyhow::Result<Self> {
+    pub fn acquire_in(dir: &Utf8Path) -> Result<Self> {
         let (project_root, raw_data) = Manifest::acquire_file_in(dir)?;
         let project_root = PrettyPath::new(&project_root);
         let data = toml_edit::de::from_str(&raw_data)?;
@@ -42,8 +43,14 @@ impl Context {
         })
     }
 
-    pub fn init(project_root: Utf8PathBuf) -> anyhow::Result<()> {
-        fs::create_dir_all(project_root.join(QueriesDir::default().as_str()))?;
+    pub fn init(project_root: Utf8PathBuf) -> Result<()> {
+        fs::create_dir_all(project_root.join(QueriesDir::default().as_str())).map_err(|cause| {
+            Error::IO {
+                path: PrettyPath::new(&project_root),
+                action: IOAction::Write,
+                cause,
+            }
+        })?;
         Manifest::init(project_root)
     }
 
@@ -85,39 +92,58 @@ impl Manifest {
         ignore = [ ".git/", ".gitignore", "/target/" ]
     "#};
 
-    fn init(project_root: Utf8PathBuf) -> anyhow::Result<()> {
+    fn init(project_root: Utf8PathBuf) -> Result<()> {
         match Manifest::acquire_file_in(&project_root) {
             Ok((found_root, _)) => return Err(Error::AlreadyInited { found_root }.into()),
-            Err(e)
-                if e.downcast_ref::<Error>()
-                    .map(|e| e != &Error::ManifestNotFound)
-                    .unwrap_or(true) =>
-            {
-                return Err(e)
-            }
-            _ => {}
+            Err(e) if matches!(e, Error::ManifestNotFound) => {}
+            Err(e) => return Err(e),
         }
 
+        let file_path = project_root.join(Self::FILE_NAME);
         let file = File::options()
             .write(true)
             .create_new(true)
-            .open(project_root.join(Self::FILE_NAME))?;
+            .open(&file_path)
+            .map_err(|cause| Error::IO {
+                path: PrettyPath::new(&file_path),
+                action: IOAction::Write,
+                cause,
+            })?;
         let mut writer = BufWriter::new(file);
-        writer.write_all(Self::DEFAULT_CONTENT.as_bytes())?;
+        writer
+            .write_all(Self::DEFAULT_CONTENT.as_bytes())
+            .map_err(|cause| Error::IO {
+                path: PrettyPath::new(&file_path),
+                action: IOAction::Write,
+                cause,
+            })?;
         Ok(())
     }
 
-    fn acquire_file() -> anyhow::Result<(Utf8PathBuf, String)> {
-        Self::acquire_file_in(&Utf8PathBuf::try_from(env::current_dir()?)?)
+    // TODO(kcza): rename this to acquire_content
+    fn acquire_file() -> Result<(Utf8PathBuf, String)> {
+        Self::acquire_file_in(&Utf8PathBuf::try_from(env::current_dir().map_err(
+            |cause| Error::IO {
+                path: PrettyPath::new(Utf8Path::new(".")),
+                action: IOAction::Read,
+                cause,
+            },
+        )?)?)
     }
 
-    fn acquire_file_in(dir: &Utf8Path) -> anyhow::Result<(Utf8PathBuf, String)> {
+    fn acquire_file_in(dir: &Utf8Path) -> Result<(Utf8PathBuf, String)> {
         let mut project_root = dir.to_path_buf();
         let mut manifest_file = loop {
             match File::open(project_root.join(Self::FILE_NAME)) {
                 Ok(f) => break f,
                 Err(e) if e.kind() == ErrorKind::NotFound => {}
-                Err(e) => return Err(e.into()),
+                Err(e) => {
+                    return Err(Error::IO {
+                        path: PrettyPath::new(&Utf8Path::new(Self::FILE_NAME)),
+                        action: IOAction::Read,
+                        cause: e,
+                    })
+                }
             }
             project_root = project_root
                 .parent()
@@ -128,7 +154,13 @@ impl Manifest {
         let len_hint = manifest_file.metadata().map(|m| m.len() as usize).ok();
         let raw_data = {
             let mut manifest_raw = String::with_capacity(len_hint.unwrap_or(0));
-            manifest_file.read_to_string(&mut manifest_raw)?;
+            manifest_file
+                .read_to_string(&mut manifest_raw)
+                .map_err(|cause| Error::IO {
+                    path: PrettyPath::new(Utf8Path::new(Self::FILE_NAME)),
+                    action: IOAction::Read,
+                    cause,
+                })?;
             manifest_raw
         };
 
@@ -184,7 +216,7 @@ impl FilePattern {
         Self(pattern.into())
     }
 
-    pub fn compile(self, project_root: &Utf8Path) -> anyhow::Result<CompiledFilePattern> {
+    pub fn compile(self, project_root: &Utf8Path) -> Result<CompiledFilePattern> {
         Ok(CompiledFilePattern(Pattern::new(
             if self.0.starts_with('/') {
                 // absolute
@@ -258,8 +290,8 @@ mod test {
     }
 
     #[test]
-    fn init() -> anyhow::Result<()> {
-        let tempdir = tempfile::tempdir()?;
+    fn init() -> Result<()> {
+        let tempdir = tempfile::tempdir().unwrap();
         let tempdir_path = Utf8PathBuf::try_from(tempdir.path().to_owned())?;
 
         // Manifest not found
@@ -291,11 +323,11 @@ mod test {
     }
 
     #[test]
-    fn no_vexes_dir() -> anyhow::Result<()> {
-        let tempdir = tempfile::tempdir()?;
+    fn no_vexes_dir() -> Result<()> {
+        let tempdir = tempfile::tempdir().unwrap();
         let tempdir_path = Utf8PathBuf::try_from(tempdir.path().to_owned())?;
 
-        File::create(tempdir_path.join("vex.toml"))?;
+        File::create(tempdir_path.join("vex.toml")).unwrap();
 
         let re = Regex::new("^cannot find vexes directory at .*").unwrap();
         let ctx = Context::acquire_in(&tempdir_path).unwrap();

--- a/src/context.rs
+++ b/src/context.rs
@@ -94,8 +94,8 @@ impl Manifest {
 
     fn init(project_root: Utf8PathBuf) -> Result<()> {
         match Manifest::acquire_file_in(&project_root) {
-            Ok((found_root, _)) => return Err(Error::AlreadyInited { found_root }.into()),
-            Err(e) if matches!(e, Error::ManifestNotFound) => {}
+            Ok((found_root, _)) => return Err(Error::AlreadyInited { found_root }),
+            Err(Error::ManifestNotFound) => {}
             Err(e) => return Err(e),
         }
 
@@ -139,7 +139,7 @@ impl Manifest {
                 Err(e) if e.kind() == ErrorKind::NotFound => {}
                 Err(e) => {
                     return Err(Error::IO {
-                        path: PrettyPath::new(&Utf8Path::new(Self::FILE_NAME)),
+                        path: PrettyPath::new(Utf8Path::new(Self::FILE_NAME)),
                         action: IOAction::Read,
                         cause: e,
                     })

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,5 @@
+use std::{io, num, path};
+
 use camino::Utf8PathBuf;
 use joinery::JoinableIterator;
 use strum::IntoEnumIterator;
@@ -5,29 +7,54 @@ use strum::IntoEnumIterator;
 use crate::{
     scriptlets::{action::Action, event::EventType},
     source_path::PrettyPath,
+    supported_language::SupportedLanguage,
 };
 
-#[derive(thiserror::Error, Debug, PartialEq)]
+// TODO(kcza): box this!
+#[derive(thiserror::Error, Debug)]
 pub enum Error {
+    #[error("{what} unavailable while {}", .action.name())]
+    ActionUnavailable { what: &'static str, action: Action },
+
     #[error("already inited in a parent directory {found_root}")]
     AlreadyInited { found_root: Utf8PathBuf },
+
+    #[error("{0}")]
+    Starlark(anyhow::Error),
+
+    #[error("{0}")]
+    Clap(#[from] clap::Error),
 
     #[error("{0} declares empty query")]
     EmptyQuery(PrettyPath),
 
+    #[error("{0}")]
+    FromPathBuf(#[from] camino::FromPathBufError),
+
     #[error("import cycle detected: {}", .0.iter().join_with(" -> "))]
     ImportCycle(Vec<PrettyPath>),
+
+    #[error("cannot {action} {path}: {cause}")]
+    IO {
+        path: PrettyPath,
+        action: IOAction,
+        cause: io::Error,
+    },
+
+    #[error("{0}")]
+    Language(#[from] tree_sitter::LanguageError),
 
     #[error("cannot find manifest, try running `vex init` in the project’s root")]
     ManifestNotFound,
 
-    // #[error("{0} has no file name")]
-    // NoFileName(Utf8PathBuf),
-    #[error("{0} declares no init function")]
-    NoInit(PrettyPath),
-
     #[error("{0} declares no callbacks")]
     NoCallbacks(PrettyPath),
+
+    #[error("{0} has no file extension")]
+    NoExtension(PrettyPath),
+
+    #[error("{0} declares no init function")]
+    NoInit(PrettyPath),
 
     #[error("{0} declares no target language")]
     NoLanguage(PrettyPath),
@@ -44,12 +71,89 @@ pub enum Error {
     #[error("cannot find vexes directory at {0}")]
     NoVexesDir(Utf8PathBuf),
 
-    #[error("{what} unavailable while {}", .action.name())]
-    Unavailable { what: &'static str, action: Action },
+    #[error("{0}")]
+    ParseInt(#[from] num::ParseIntError),
+
+    #[error("{0}")]
+    Pattern(#[from] glob::PatternError),
+
+    #[error("{0}")]
+    Query(#[from] tree_sitter::QueryError),
+
+    #[error("{0}")]
+    SetLogger(#[from] log::SetLoggerError),
+
+    #[error("{0}")]
+    StripPrefix(#[from] path::StripPrefixError),
+
+    #[error("{0}")]
+    Toml(#[from] toml_edit::de::Error),
 
     #[error("unknown event '{0}', expected one of: {}", EventType::iter().join_with(", "))]
     UnknownEvent(String),
 
+    #[error("unknown extension '{0}'")]
+    UnknownExtension(String),
+
     #[error("unknown language '{0}'")]
     UnknownLanguage(String),
+
+    #[error("cannot parse {path} as {language}")]
+    Unparseable {
+        path: PrettyPath,
+        language: SupportedLanguage,
+    },
+}
+
+impl Error {
+    pub fn is_recoverable(&self) -> bool {
+        match self {
+            Self::ActionUnavailable { .. }
+            | Self::AlreadyInited { .. }
+            | Self::Clap { .. }
+            | Self::EmptyQuery(..)
+            | Self::FromPathBuf { .. }
+            | Self::ImportCycle(..)
+            | Self::Language(..)
+            | Self::ManifestNotFound
+            | Self::NoCallbacks(..)
+            | Self::NoInit(..)
+            | Self::NoLanguage(..)
+            | Self::NoMatch(..)
+            | Self::NoQuery(..)
+            | Self::NoSuchModule(..)
+            | Self::NoVexesDir(..)
+            | Self::ParseInt(..)
+            | Self::Pattern(..)
+            | Self::Query(..)
+            | Self::SetLogger(..)
+            | Self::Starlark { .. }
+            | Self::StripPrefix(..)
+            | Self::Toml(..)
+            | Self::UnknownEvent(..)
+            | Self::UnknownLanguage(..) => false,
+            Self::IO { .. }
+            | Self::NoExtension(..)
+            | Self::UnknownExtension { .. }
+            | Self::Unparseable { .. } => true,
+        }
+    }
+}
+
+impl Error {
+    pub fn starlark(err: anyhow::Error) -> Self {
+        match err.downcast().map_err(Error::Starlark) {
+            Ok(err) => err,
+            Err(err) => err,
+        }
+    }
+}
+
+#[derive(Debug, strum::Display)]
+pub enum IOAction {
+    #[strum(serialize = "read")]
+    Read,
+
+    #[strum(serialize = "write")]
+    Write,
 }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -3,12 +3,12 @@ use std::{process::ExitCode, sync::Mutex};
 use annotate_snippets::{AnnotationType, Renderer, Snippet};
 use log::{kv::Key, Level, Log, Metadata, Record};
 
-use crate::verbosity::Verbosity;
+use crate::{verbosity::Verbosity, result::Result};
 
 static NUM_ERRS: Mutex<u32> = Mutex::new(0);
 static NUM_WARNINGS: Mutex<u32> = Mutex::new(0);
 
-pub fn init(level: Verbosity) -> anyhow::Result<()> {
+pub fn init(level: Verbosity) -> Result<()> {
     let level = level.into();
     log::set_boxed_logger(Box::new(Logger { level }))?;
     log::set_max_level(level.to_level_filter());

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -3,7 +3,7 @@ use std::{process::ExitCode, sync::Mutex};
 use annotate_snippets::{AnnotationType, Renderer, Snippet};
 use log::{kv::Key, Level, Log, Metadata, Record};
 
-use crate::{verbosity::Verbosity, result::Result};
+use crate::{result::Result, verbosity::Verbosity};
 
 static NUM_ERRS: Mutex<u32> = Mutex::new(0);
 static NUM_WARNINGS: Mutex<u32> = Mutex::new(0);

--- a/src/main.rs
+++ b/src/main.rs
@@ -380,7 +380,7 @@ mod test {
         if cfg!(target_os = "windows") {
             assert_eq!(
                 err.to_string(),
-                "cannot read /i/do/not/exist.rs: The system cannot find the path specified (os error 3)"
+                "cannot read /i/do/not/exist.rs: The system cannot find the path specified. (os error 3)"
             );
         } else {
             assert_eq!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -377,10 +377,17 @@ mod test {
         let args = Args::try_parse_from(["vex", "dump", file_path]).unwrap();
         let cmd = args.command.into_dump_cmd().unwrap();
         let err = dump(cmd).unwrap_err();
-        assert_eq!(
-            err.to_string(),
-            "cannot read /i/do/not/exist.rs: No such file or directory (os error 2)"
-        );
+        if cfg!(target_os = "windows") {
+            assert_eq!(
+                err.to_string(),
+                "cannot read /i/do/not/exist.rs: The system cannot find the path specified (os error 3)"
+            );
+        } else {
+            assert_eq!(
+                err.to_string(),
+                "cannot read /i/do/not/exist.rs: No such file or directory (os error 2)"
+            );
+        }
     }
 
     #[test]
@@ -407,10 +414,10 @@ mod test {
         let cmd = args.command.into_dump_cmd().unwrap();
         let err = dump(cmd).unwrap_err();
 
-        // Assertion relaxed due to strange Github Actions Macos runner path handling.
-        let expected = format!("{} has no file extension", test_file.path);
+        // Assertion relaxed due to strange Github Actions Windows and Macos runner path handling.
+        let expected = "no-extension has no file extension";
         assert!(
-            err.to_string().contains(&expected),
+            err.to_string().ends_with(&expected),
             "unexpected error: expected {expected} but got {err}"
         );
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -406,9 +406,12 @@ mod test {
         let args = Args::try_parse_from(["vex", "dump", test_file.path.as_str()]).unwrap();
         let cmd = args.command.into_dump_cmd().unwrap();
         let err = dump(cmd).unwrap_err();
-        assert_eq!(
-            err.to_string(),
-            format!("{} has no file extension", test_file.path)
+
+        // Assertion relaxed due to strange Github Actions Macos runner path handling.
+        let expected = format!("{} has no file extension", test_file.path);
+        assert!(
+            err.to_string().contains(&expected),
+            "unexpected error: expected {expected} but got {err}"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -268,9 +268,7 @@ fn walkdir(
 }
 
 fn dump(dump_args: DumpCmd) -> anyhow::Result<()> {
-    let ctx = Context::acquire()?;
-
-    let src_path = SourcePath::new(&dump_args.path.canonicalize_utf8()?, &ctx.project_root);
+    let src_path = SourcePath::new_absolute(&dump_args.path.canonicalize_utf8()?);
     let Some(src_file) = SourceFile::load_if_supported(src_path) else {
         return Ok(()); // Load already logs.
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ use std::{env, fs, process::ExitCode};
 
 use camino::{Utf8Path, Utf8PathBuf};
 use clap::Parser as _;
+use cli::DumpCmd;
 use dupe::Dupe;
 use log::{info, log_enabled, trace};
 use strum::IntoEnumIterator;
@@ -52,6 +53,7 @@ fn main() -> anyhow::Result<ExitCode> {
         Command::ListLanguages => list_languages(),
         Command::ListLints => list_lints(),
         Command::Check(cmd_args) => check(cmd_args),
+        Command::Dump(dump_args) => dump(dump_args),
         Command::Init => init(),
     }?;
 
@@ -261,6 +263,20 @@ fn walkdir(
             panic!("unreachable");
         }
     }
+
+    Ok(())
+}
+
+fn dump(dump_args: DumpCmd) -> anyhow::Result<()> {
+    let ctx = Context::acquire()?;
+
+    let src_path = SourcePath::new(&dump_args.path.canonicalize_utf8()?, &ctx.project_root);
+    let Some(src_file) = SourceFile::load_if_supported(src_path) else {
+        return Ok(()); // Load already logs.
+    };
+    let src_file = src_file?;
+
+    println!("{}", src_file.tree.root_node().to_sexp());
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -245,13 +245,13 @@ fn walkdir(
         trace!("walking {path}");
     }
     let entries = fs::read_dir(path).map_err(|cause| Error::IO {
-        path: PrettyPath::new(&path),
+        path: PrettyPath::new(path),
         action: IOAction::Read,
         cause,
     })?;
     for entry in entries {
         let entry = entry.map_err(|cause| Error::IO {
-            path: PrettyPath::new(&path),
+            path: PrettyPath::new(path),
             action: IOAction::Read,
             cause,
         })?;
@@ -304,8 +304,7 @@ fn dump(dump_args: DumpCmd) -> Result<()> {
         return Err(Error::Unparseable {
             path: PrettyPath::new(Utf8Path::new(&dump_args.path)),
             language: src_file.lang,
-        }
-        .into());
+        });
     }
 
     println!("{}", src_file.tree.root_node().to_sexp());

--- a/src/main.rs
+++ b/src/main.rs
@@ -366,7 +366,7 @@ mod test {
             "#},
         );
 
-        let args = Args::try_parse_from(&["vex", "dump", test_file.path.as_str()]).unwrap();
+        let args = Args::try_parse_from(["vex", "dump", test_file.path.as_str()]).unwrap();
         let cmd = args.command.into_dump_cmd().unwrap();
         dump(cmd).unwrap();
     }
@@ -374,7 +374,7 @@ mod test {
     #[test]
     fn dump_nonexistent_file() {
         let file_path = "/i/do/not/exist.rs";
-        let args = Args::try_parse_from(&["vex", "dump", file_path]).unwrap();
+        let args = Args::try_parse_from(["vex", "dump", file_path]).unwrap();
         let cmd = args.command.into_dump_cmd().unwrap();
         let err = dump(cmd).unwrap_err();
         assert_eq!(
@@ -391,7 +391,7 @@ mod test {
                 i am not valid a valid rust file!
             "#},
         );
-        let args = Args::try_parse_from(&["vex", "dump", test_file.path.as_str()]).unwrap();
+        let args = Args::try_parse_from(["vex", "dump", test_file.path.as_str()]).unwrap();
         let cmd = args.command.into_dump_cmd().unwrap();
         let err = dump(cmd).unwrap_err();
         assert_eq!(
@@ -403,7 +403,7 @@ mod test {
     #[test]
     fn no_extension() {
         let test_file = TestFile::new("no-extension", "");
-        let args = Args::try_parse_from(&["vex", "dump", test_file.path.as_str()]).unwrap();
+        let args = Args::try_parse_from(["vex", "dump", test_file.path.as_str()]).unwrap();
         let cmd = args.command.into_dump_cmd().unwrap();
         let err = dump(cmd).unwrap_err();
         assert_eq!(
@@ -415,7 +415,7 @@ mod test {
     #[test]
     fn unknown_extension() {
         let test_file = TestFile::new("file.unknown-extension", "");
-        let args = Args::try_parse_from(&["vex", "dump", test_file.path.as_str()]).unwrap();
+        let args = Args::try_parse_from(["vex", "dump", test_file.path.as_str()]).unwrap();
         let cmd = args.command.into_dump_cmd().unwrap();
         let err = dump(cmd).unwrap_err();
         assert_eq!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,7 +49,7 @@ fn main() -> anyhow::Result<ExitCode> {
     let args = Args::parse();
     logger::init(Verbosity::try_from(args.verbosity_level)?)?;
 
-    match args.command.unwrap_or_default() {
+    match args.command {
         Command::ListLanguages => list_languages(),
         Command::ListLints => list_lints(),
         Command::Check(cmd_args) => check(cmd_args),

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,0 +1,3 @@
+use crate::error::Error;
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/src/scriptlets/app_object.rs
+++ b/src/scriptlets/app_object.rs
@@ -12,6 +12,7 @@ use starlark_derive::starlark_value;
 
 use crate::{
     error::Error,
+    result::Result,
     scriptlets::{
         action::Action,
         event::EventType,
@@ -90,11 +91,11 @@ impl AppObject {
     fn check_attr_available(
         eval: &Evaluator<'_, '_>,
         attr_path: &'static str,
-        available_actions: &[Action],
-    ) -> anyhow::Result<()> {
+        available_actions: &'static [Action],
+    ) -> Result<()> {
         let curr_action = InvocationData::get_from(eval).action();
         if !available_actions.contains(&curr_action) {
-            return Err(Error::Unavailable {
+            return Err(Error::ActionUnavailable {
                 what: attr_path,
                 action: curr_action,
             }
@@ -114,7 +115,7 @@ impl<'v> StarlarkValue<'v> for AppObject {
 }
 
 impl Display for AppObject {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         Self::NAME.fmt(f)
     }
 }

--- a/src/scriptlets/app_object.rs
+++ b/src/scriptlets/app_object.rs
@@ -98,8 +98,7 @@ impl AppObject {
             return Err(Error::ActionUnavailable {
                 what: attr_path,
                 action: curr_action,
-            }
-            .into());
+            });
         }
         Ok(())
     }

--- a/src/scriptlets/extra_data.rs
+++ b/src/scriptlets/extra_data.rs
@@ -15,6 +15,7 @@ use tree_sitter::Query;
 
 use crate::{
     error::Error,
+    result::Result,
     scriptlets::{
         action::Action,
         event::EventType,
@@ -244,7 +245,7 @@ impl FrozenObserverDataBuilder {
             .expect("FrozenModule extra has wrong type")
     }
 
-    pub fn build(&self) -> anyhow::Result<ScriptletObserverData> {
+    pub fn build(&self) -> Result<ScriptletObserverData> {
         let Self {
             path,
             lang,

--- a/src/scriptlets/extra_data.rs
+++ b/src/scriptlets/extra_data.rs
@@ -260,16 +260,16 @@ impl FrozenObserverDataBuilder {
         let path = path.dupe();
         let lang = {
             let Some(lang) = lang else {
-                return Err(Error::NoLanguage(path).into());
+                return Err(Error::NoLanguage(path));
             };
             lang.parse::<SupportedLanguage>()?
         };
         let query = {
             let Some(query) = query else {
-                return Err(Error::NoQuery(path).into());
+                return Err(Error::NoQuery(path));
             };
             if query.is_empty() {
-                return Err(Error::EmptyQuery(path).into());
+                return Err(Error::EmptyQuery(path));
             }
             Arc::new(Query::new(lang.ts_language(), query)?)
         };
@@ -280,10 +280,10 @@ impl FrozenObserverDataBuilder {
             && on_close_file.is_empty()
             && on_close_project.is_empty()
         {
-            return Err(Error::NoCallbacks(path).into());
+            return Err(Error::NoCallbacks(path));
         }
         if on_match.is_empty() {
-            return Err(Error::NoMatch(path).into());
+            return Err(Error::NoMatch(path));
         }
         let on_open_project = Arc::new(
             on_open_project

--- a/src/scriptlets/scriptlet.rs
+++ b/src/scriptlets/scriptlet.rs
@@ -126,7 +126,7 @@ impl InitingScriptlet {
             .map_err(Error::starlark)?
         else {
             if toplevel {
-                return Err(Error::NoInit(path.pretty_path.dupe()).into());
+                return Err(Error::NoInit(path.pretty_path.dupe()));
             }
             // Non-toplevel scriptlets may be helper libraries.
             return Ok(VexingScriptlet {

--- a/src/scriptlets/store.rs
+++ b/src/scriptlets/store.rs
@@ -132,7 +132,7 @@ impl PreinitingStore {
                 .filter(|l| self.path_indices.get(l).is_none())
         });
         if let Some(unknown_module) = unknown_loads.next() {
-            return Err(Error::NoSuchModule(unknown_module.dupe()).into());
+            return Err(Error::NoSuchModule(unknown_module.dupe()));
         }
         Ok(())
     }
@@ -189,16 +189,16 @@ impl PreinitingStore {
                 node,
             );
         }
+        // Presence of an import cycle will prevent some nodes entering the
+        // linearisation.
         if linearised.len() != self.store.len() {
-            // Presence of an import cycle will prevent some nodes entering the
-            // linearisation.
-            return Err(Error::ImportCycle(self.find_cycle()).into());
+            return Err(Error::ImportCycle(self.find_cycle()));
         }
-        linearised.into_iter().enumerate().for_each(|(i, j)| {
-            if i < j {
-                self.store.swap(i, j)
-            }
-        });
+        linearised
+            .into_iter()
+            .enumerate()
+            .filter(|(i, j)| i < j)
+            .for_each(|(i, j)| self.store.swap(i, j));
 
         Ok(())
     }

--- a/src/source_path.rs
+++ b/src/source_path.rs
@@ -28,6 +28,13 @@ impl SourcePath {
         }
     }
 
+    pub fn new_absolute(path: &Utf8Path) -> Self {
+        Self {
+            abs_path: path.into(),
+            pretty_path: PrettyPath::new(path),
+        }
+    }
+
     pub fn as_str(&self) -> &str {
         self.pretty_path.as_str()
     }

--- a/src/supported_language.rs
+++ b/src/supported_language.rs
@@ -43,7 +43,7 @@ impl FromStr for SupportedLanguage {
     fn from_str(s: &str) -> Result<Self> {
         match s {
             "rust" => Ok(Self::Rust),
-            _ => Err(Error::UnknownLanguage(s.to_string()).into()),
+            _ => Err(Error::UnknownLanguage(s.to_string())),
         }
     }
 }

--- a/src/supported_language.rs
+++ b/src/supported_language.rs
@@ -7,7 +7,7 @@ use enum_map::Enum;
 use strum::EnumIter;
 use tree_sitter::Language;
 
-use crate::error::Error;
+use crate::{error::Error, result::Result};
 
 #[derive(Copy, Clone, Debug, Dupe, EnumIter, Subcommand, Enum, Allocative, PartialEq, Eq)]
 pub enum SupportedLanguage {
@@ -22,10 +22,10 @@ impl SupportedLanguage {
         }
     }
 
-    pub fn try_from_extension(extension: &str) -> Option<Self> {
+    pub fn try_from_extension(extension: &str) -> Result<Self> {
         match extension {
-            "rs" => Some(Self::Rust),
-            _ => None,
+            "rs" => Ok(Self::Rust),
+            _ => Err(Error::UnknownExtension(extension.into())),
         }
     }
 
@@ -38,9 +38,9 @@ impl SupportedLanguage {
 }
 
 impl FromStr for SupportedLanguage {
-    type Err = anyhow::Error;
+    type Err = Error;
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+    fn from_str(s: &str) -> Result<Self> {
         match s {
             "rust" => Ok(Self::Rust),
             _ => Err(Error::UnknownLanguage(s.to_string()).into()),

--- a/src/vextest.rs
+++ b/src/vextest.rs
@@ -9,7 +9,9 @@ use camino::Utf8PathBuf;
 use indoc::indoc;
 use regex::Regex;
 
-use crate::{context::Context, irritation::Irritation, scriptlets::PreinitingStore};
+use crate::{
+    context::Context, irritation::Irritation, result::Result, scriptlets::PreinitingStore,
+};
 
 pub struct VexTest<'s> {
     name: Cow<'s, str>,
@@ -109,7 +111,7 @@ impl<'s> VexTest<'s> {
         );
     }
 
-    pub fn try_run(mut self) -> anyhow::Result<Vec<Irritation>> {
+    pub fn try_run(mut self) -> Result<Vec<Irritation>> {
         self.setup();
 
         let root_dir = tempfile::tempdir().unwrap();
@@ -119,7 +121,8 @@ impl<'s> VexTest<'s> {
             let manifest_content = self.manifest_content.as_deref().unwrap_or_default();
             File::create(root_path.join("vex.toml"))
                 .unwrap()
-                .write_all(manifest_content.as_bytes())?;
+                .write_all(manifest_content.as_bytes())
+                .unwrap();
         }
 
         for (path, content) in &self.scriptlets {


### PR DESCRIPTION
This PR adds a new subcommand to show the s-expression form parsed from source files. This will assist with query-writing.

This PR also overhauls error handling to improve formality and remove awkward `downcast_ref` calls when reacting to specific errors. This is required as the previous `anyhow`-based error handling did not bond well with different behaviours in response to unreadable/unrecognisable files
