### PR TITLE
Implement `vex.warn`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,6 +199,9 @@ name = "camino"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cc"
@@ -277,6 +280,18 @@ name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "console"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "convert_case"
@@ -417,6 +432,12 @@ checksum = "c533630cf40e9caa44bd91aadc88a75d75a4c3a12b4cfde353cbed41daa1e1f1"
 dependencies = [
  "log",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "endian-type"
@@ -604,6 +625,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
 
 [[package]]
+name = "insta"
+version = "1.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7c22c4d34ef4788c351e971c52bfdfe7ea2766f8c5466bc175dd46e52ac22e"
+dependencies = [
+ "console",
+ "lazy_static",
+ "linked-hash-map",
+ "serde",
+ "similar",
+ "yaml-rust",
+]
+
+[[package]]
 name = "inventory"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -694,6 +729,12 @@ dependencies = [
  "libc",
  "redox_syscall",
 ]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1155,6 +1196,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "similar"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32fea41aca09ee824cc9724996433064c89f7777e60762749a4170a14abbfa21"
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1535,6 +1582,7 @@ dependencies = [
  "enum-map",
  "glob",
  "indoc",
+ "insta",
  "joinery",
  "lazy_static",
  "log",
@@ -1719,6 +1767,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b5c3db89721d50d0e2a673f5043fc4722f76dcc352d7b1ab8b8288bed4ed2c5"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ allocative = "0.3.1"
 annotate-snippets = "0.10.0"
 anyhow = "1.0.76"
 async-recursion = "1.0.5"
-camino = "1.1.6"
+camino = { version = "1.1.6", features = ["serde1"] }
 clap = { version = "4.4.11", features = ["derive"] }
 derive-new = "0.6.0"
 derive_more = "0.99.17"
@@ -22,7 +22,7 @@ joinery = "3.1.0"
 lazy_static = "1.4.0"
 log = { version = "0.4.20", features = ["std", "kv_unstable"] }
 num-traits = "0.2.17"
-serde = { version = "1.0.193", features = ["derive"] }
+serde = { version = "1.0.193", features = ["derive", "rc"] }
 starlark = "0.10.0"
 starlark_derive = "0.10.0"
 strum = { version = "0.25.0", features = ["derive"] }
@@ -33,5 +33,10 @@ tree-sitter = "0.20.10"
 tree-sitter-rust = "0.20.4"
 
 [dev-dependencies]
+insta = { version = "1.36.1", features = ["yaml"] }
 pretty_assertions = "1.4.0"
 regex = "1.10.3"
+
+[profile.dev.package]
+insta.opt-level = 3
+similar.opt-level = 3

--- a/src/error.rs
+++ b/src/error.rs
@@ -34,6 +34,9 @@ pub enum Error {
     #[error("import cycle detected: {}", .0.iter().join_with(" -> "))]
     ImportCycle(Vec<PrettyPath>),
 
+    #[error("{0}")]
+    InvalidWarnCall(&'static str),
+
     #[error("cannot {action} {path}: {cause}")]
     IO {
         path: PrettyPath,
@@ -117,6 +120,7 @@ impl Error {
             | Self::EmptyQuery(..)
             | Self::FromPathBuf { .. }
             | Self::ImportCycle(..)
+            | Self::InvalidWarnCall(..)
             | Self::Language(..)
             | Self::ManifestNotFound
             | Self::NoCallbacks(..)

--- a/src/irritation.rs
+++ b/src/irritation.rs
@@ -100,13 +100,13 @@ impl<'v> IrritationRenderer<'v> {
         let snippet = Snippet {
             title: Some(Annotation {
                 id: Some(vex_path.file_stem().expect("vex has no file stem")),
-                label: Some(&message),
+                label: Some(message),
                 annotation_type: AnnotationType::Warning,
             }),
             slices: source
                 .iter()
                 .map(|(node, label)| {
-                    let range = Self::relevant_range(&node);
+                    let range = Self::relevant_range(node);
                     Slice {
                         source: &node.source_file.content[range.start..range.end],
                         // overhead!

--- a/src/irritation.rs
+++ b/src/irritation.rs
@@ -97,6 +97,9 @@ impl<'v> IrritationRenderer<'v> {
 
         // TODO(kcza): allow source and show_alsos to be in separate files.
 
+        let file_name = source
+            .as_ref()
+            .map(|source| source.0.source_file.path.pretty_path.as_str());
         let snippet = Snippet {
             title: Some(Annotation {
                 id: Some(vex_path.file_stem().expect("vex has no file stem")),
@@ -111,7 +114,7 @@ impl<'v> IrritationRenderer<'v> {
                         source: &node.source_file.content[range.start..range.end],
                         // overhead!
                         line_start: 1 + node.start_position().row,
-                        origin: Some(node.source_file.path.pretty_path.as_str()),
+                        origin: Some(file_name.as_ref().unwrap()),
                         annotations: [SourceAnnotation {
                             range: (
                                 node.start_byte() - range.start,

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -85,5 +85,11 @@ fn annotation_type_of(level: Level) -> AnnotationType {
 }
 
 pub fn render_snippet(snippet: Snippet) -> String {
-    Renderer::styled().render(snippet).to_string()
+    if !cfg!(test) {
+        Renderer::styled()
+    } else {
+        Renderer::plain()
+    }
+    .render(snippet)
+    .to_string()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,7 +84,9 @@ fn list_languages() -> Result<()> {
 fn list_lints() -> Result<()> {
     let ctx = Context::acquire()?;
     let store = PreinitingStore::new(&ctx)?.preinit()?;
-    store.vexes().for_each(|vex| println!("{}", vex.path));
+    store
+        .vexes()
+        .for_each(|vex| println!("{}", vex.path.pretty_path));
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,9 +25,9 @@ use std::{env, fs, process::ExitCode};
 
 use camino::{Utf8Path, Utf8PathBuf};
 use clap::Parser as _;
-use cli::DumpCmd;
+use cli::{DumpCmd, MaxProblems};
 use dupe::Dupe;
-use log::{info, log_enabled, trace};
+use log::{info, log_enabled, trace, warn};
 use starlark::environment::Module;
 use strum::IntoEnumIterator;
 use tree_sitter::QueryCursor;
@@ -37,6 +37,7 @@ use crate::{
     context::{CompiledFilePattern, Context},
     error::{Error, IOAction},
     irritation::Irritation,
+    plural::Plural,
     result::Result,
     scriptlets::{
         event::CloseProjectEvent,
@@ -87,33 +88,23 @@ fn list_lints() -> Result<()> {
     Ok(())
 }
 
-fn check(_cmd_args: CheckCmd) -> Result<()> {
+fn check(cmd_args: CheckCmd) -> Result<()> {
     let ctx = Context::acquire()?;
     let store = PreinitingStore::new(&ctx)?.preinit()?.init()?;
 
-    let irritations = vex(&ctx, &store)?;
-    println!("Got irritations: {irritations:?}");
+    let irritations = vex(&ctx, &store, cmd_args.max_problems)?;
+    irritations.iter().for_each(|irr| println!("{irr}"));
+    warn!(
+        // "scanned {} and found {}",
+        // Plural::new(npaths, "path", "paths"),
+        "vex found {}",
+        Plural::new(irritations.len(), "problem", "problems"),
+    );
 
-    // if let MaxProblems::Limited(max_problems) = cmd_args.max_problems {
-    //     problems.truncate(max_problems as usize);
-    // }
-    // problems.sort();
-    // for problem in &problems {
-    //     if log_enabled!(log::Level::Warn) {
-    //         warn!(target: "vex", custom = true; "{problem}");
-    //     }
-    // }
-    // if log_enabled!(log::Level::Info) {
-    //     info!(
-    //         "scanned {} and found {}",
-    //         Plural::new(npaths, "path", "paths"),
-    //         Plural::new(problems.len(), "problem", "problems"),
-    //     );
-    // }
     Ok(())
 }
 
-fn vex(ctx: &Context, store: &VexingStore) -> Result<Vec<Irritation>> {
+fn vex(ctx: &Context, store: &VexingStore, max_problems: MaxProblems) -> Result<Vec<Irritation>> {
     let language_observers = store.language_observers();
     let paths = {
         let mut paths = Vec::new();
@@ -150,12 +141,12 @@ fn vex(ctx: &Context, store: &VexingStore) -> Result<Vec<Irritation>> {
             let handler_module = Module::new();
             on_open_project.handle(
                 &handler_module,
-                &observer.path,
+                &observer.path, // TODO(kcza): what path is this??
                 OpenProjectEvent::new(ctx.project_root.dupe()),
             )?;
         }
     }
-    // let mut irritations = Vec::new();
+    let mut irritations = Vec::new();
     for path in paths {
         let src_file = match SourceFile::load(path.dupe()) {
             Ok(f) => f,
@@ -170,60 +161,51 @@ fn vex(ctx: &Context, store: &VexingStore) -> Result<Vec<Irritation>> {
             }
         };
 
-        println!("linting {}...", src_file.path);
         for observer in &language_observers[src_file.lang] {
             for on_open_file in &observer.on_open_file[..] {
                 let handler_module = Module::new();
-                on_open_file.handle(
+                irritations.extend(on_open_file.handle(
                     &handler_module,
                     &observer.path,
                     OpenFileEvent::new(src_file.path.pretty_path.dupe()),
-                )?;
+                )?);
             }
 
-            println!("running a handler set...");
             for qmatch in QueryCursor::new().matches(
                 observer.query.as_ref(),
                 src_file.tree.root_node(),
                 src_file.content[..].as_bytes(),
             ) {
-                println!("found {qmatch:?}");
                 let captures = QueryCaptures::new(&observer.query, &qmatch, &src_file);
                 for on_match in &observer.on_match[..] {
                     let handler_module = Module::new();
-                    on_match.handle(
+                    irritations.extend(on_match.handle(
                         &handler_module,
                         &observer.path,
                         MatchEvent::new(src_file.path.pretty_path.dupe(), captures.dupe()),
-                    )?;
+                    )?);
                 }
             }
 
             for on_close_file in &observer.on_close_file[..] {
                 let handler_module = Module::new();
-                on_close_file.handle(
+                irritations.extend(on_close_file.handle(
                     &handler_module,
                     &observer.path,
                     CloseFileEvent::new(src_file.path.pretty_path.dupe()),
-                )?;
+                )?);
             }
         }
-
-        // let mut vex_irritations = Vec::new();
-        // for vex in vexes {
-        //     vex_irritations.extend(vex.check(&src_file)?);
-        // }
-        // irritations.push((vex.id, vex_irritations));
     }
     for language_observer in language_observers.values() {
         for observer in language_observer {
             for on_close_project in &observer.on_close_project[..] {
                 let handler_module = Module::new();
-                on_close_project.handle(
+                irritations.extend(on_close_project.handle(
                     &handler_module,
                     &observer.path,
                     CloseProjectEvent::new(ctx.project_root.dupe()),
-                )?;
+                )?);
             }
         }
     }
@@ -251,9 +233,15 @@ fn vex(ctx: &Context, store: &VexingStore) -> Result<Vec<Irritation>> {
     //         break;
     //     }
     // }
-    //
 
-    Ok(vec![])
+    irritations.sort();
+    if let MaxProblems::Limited(max) = max_problems {
+        let max = max as usize;
+        if max < irritations.len() {
+            irritations.truncate(max);
+        }
+    }
+    Ok(irritations)
 }
 
 fn walkdir(
@@ -349,6 +337,8 @@ mod test {
 
     use indoc::indoc;
     use tempfile::TempDir;
+
+    use crate::vextest::VexTest;
 
     use super::*;
 
@@ -454,5 +444,45 @@ mod test {
             err.to_string(),
             format!("unknown extension 'unknown-extension'")
         );
+    }
+
+    #[test]
+    fn max_problems() {
+        const MAX: u32 = 47;
+        let irritations = VexTest::new("max-problems")
+            .with_max_problems(MaxProblems::Limited(MAX))
+            .with_scriptlet(
+                "vexes/var.star",
+                indoc! {r#"
+                    def init():
+                        vex.language('rust')
+                        vex.query('(integer_literal) @num')
+                        vex.observe('match', on_match)
+
+                    def on_match(event):
+                        vex.warn('oh no a number!', at=(event.captures['num'], 'num'))
+                "#},
+            )
+            .with_source_file(
+                "src/main.rs",
+                indoc! {r#"
+                    fn main() {
+                        let x = 1 + 2 + 3 + 4 + 5 + 6 + 8 + 9 + 10;
+                        let x = 1 + 2 + 3 + 4 + 5 + 6 + 8 + 9 + 10;
+                        let x = 1 + 2 + 3 + 4 + 5 + 6 + 8 + 9 + 10;
+                        let x = 1 + 2 + 3 + 4 + 5 + 6 + 8 + 9 + 10;
+                        let x = 1 + 2 + 3 + 4 + 5 + 6 + 8 + 9 + 10;
+                        let x = 1 + 2 + 3 + 4 + 5 + 6 + 8 + 9 + 10;
+                        let x = 1 + 2 + 3 + 4 + 5 + 6 + 8 + 9 + 10;
+                        let x = 1 + 2 + 3 + 4 + 5 + 6 + 8 + 9 + 10;
+                        let x = 1 + 2 + 3 + 4 + 5 + 6 + 8 + 9 + 10;
+                        let x = 1 + 2 + 3 + 4 + 5 + 6 + 8 + 9 + 10;
+                        println!("{x}");
+                    }
+                "#},
+            )
+            .try_run()
+            .unwrap();
+        assert_eq!(irritations.len(), MAX as usize);
     }
 }

--- a/src/scriptlets.rs
+++ b/src/scriptlets.rs
@@ -9,9 +9,10 @@ mod query_captures;
 mod scriptlet;
 mod store;
 
-pub use observers::{Observer, ScriptletObserverData};
-pub use query_captures::QueryCaptures;
-pub use store::{PreinitingStore, VexingStore};
+pub use self::node::Node;
+pub use self::observers::{Observer, ScriptletObserverData};
+pub use self::query_captures::QueryCaptures;
+pub use self::store::{PreinitingStore, VexingStore};
 
 #[cfg(test)]
 pub use print_handler::PrintHandler;

--- a/src/scriptlets/app_object.rs
+++ b/src/scriptlets/app_object.rs
@@ -198,6 +198,7 @@ mod test {
             )
             .try_run()
             .unwrap()
+            .into_irritations()
             .into_iter()
             .map(|irr| irr.to_string())
             .collect::<Vec<_>>();
@@ -317,6 +318,7 @@ mod test {
             )
             .try_run()
             .unwrap()
+            .into_irritations()
             .into_iter()
             .map(|irr| irr.to_string())
             .collect::<Vec<_>>();

--- a/src/scriptlets/app_object.rs
+++ b/src/scriptlets/app_object.rs
@@ -22,12 +22,15 @@ use crate::{
     },
 };
 
+type StarlarkSourceAnnotation<'v> = (Node<'v>, &'v str);
+
 #[derive(Debug, PartialEq, Eq, ProvidesStaticType, NoSerialize, Allocative)]
 pub struct AppObject;
 
 impl AppObject {
     pub const NAME: &'static str = "vex";
 
+    #[allow(clippy::type_complexity)]
     #[starlark_module]
     fn methods(builder: &mut MethodsBuilder) {
         fn language<'v>(
@@ -71,8 +74,8 @@ impl AppObject {
         fn warn<'v>(
             #[starlark(this)] _this: Value<'v>,
             #[starlark(require=pos)] message: &'v str,
-            at: Option<(Node<'v>, &'v str)>,
-            show_also: Option<Vec<(Node<'v>, &'v str)>>,
+            at: Option<StarlarkSourceAnnotation>,
+            show_also: Option<Vec<StarlarkSourceAnnotation>>,
             extra_info: Option<&'v str>,
             eval: &mut Evaluator<'v, '_>,
         ) -> anyhow::Result<NoneType> {

--- a/src/scriptlets/app_object.rs
+++ b/src/scriptlets/app_object.rs
@@ -1,22 +1,24 @@
 use std::fmt::Display;
 
 use allocative::Allocative;
+use dupe::Dupe;
 use starlark::{
     environment::{Methods, MethodsBuilder, MethodsStatic},
     eval::Evaluator,
     starlark_module,
-    values::Value,
-    values::{none::NoneType, NoSerialize, ProvidesStaticType, StarlarkValue},
+    values::{none::NoneType, NoSerialize, ProvidesStaticType, StarlarkValue, Value},
 };
 use starlark_derive::starlark_value;
 
 use crate::{
     error::Error,
+    irritation::IrritationRenderer,
     result::Result,
     scriptlets::{
         action::Action,
         event::EventType,
         extra_data::{InvocationData, ObserverDataBuilder},
+        Node,
     },
 };
 
@@ -47,7 +49,6 @@ impl AppObject {
         ) -> anyhow::Result<NoneType> {
             AppObject::check_attr_available(eval, "vex.query", &[Action::Initing])?;
 
-            // TODO(kcza): attach the id in errors somewhere?
             ObserverDataBuilder::get_from(eval.module()).set_query(query.into());
 
             Ok(NoneType)
@@ -69,7 +70,10 @@ impl AppObject {
 
         fn warn<'v>(
             #[starlark(this)] _this: Value<'v>,
-            _msg: &'v str,
+            #[starlark(require=pos)] message: &'v str,
+            at: Option<(Node<'v>, &'v str)>,
+            show_also: Option<Vec<(Node<'v>, &'v str)>>,
+            extra_info: Option<&'v str>,
             eval: &mut Evaluator<'v, '_>,
         ) -> anyhow::Result<NoneType> {
             AppObject::check_attr_available(
@@ -83,7 +87,27 @@ impl AppObject {
                 ],
             )?;
 
-            // TODO(kcza): complete me!
+            if matches!((&at, &show_also), (None, Some(_))) {
+                return Err(Error::InvalidWarnCall(
+                    "cannot display `show_also` without an `at` argument",
+                )
+                .into());
+            }
+
+            let inv_data = InvocationData::get_from(eval);
+            let vex_path = inv_data.path();
+            let mut renderer = IrritationRenderer::new(vex_path.dupe(), message);
+            if let Some(at) = at {
+                renderer.set_source(at)
+            }
+            if let Some(show_also) = show_also {
+                renderer.set_show_also(show_also);
+            }
+            if let Some(extra_info) = extra_info {
+                renderer.set_extra_info(extra_info);
+            }
+            inv_data.add_irritation(renderer.render());
+
             Ok(NoneType)
         }
     }
@@ -116,5 +140,208 @@ impl<'v> StarlarkValue<'v> for AppObject {
 impl Display for AppObject {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         Self::NAME.fmt(f)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use indoc::{formatdoc, indoc};
+    use insta::assert_yaml_snapshot;
+
+    use crate::vextest::VexTest;
+
+    #[test]
+    fn warn_valid() {
+        const VEX_NAME: &'static str = "name_of_vex";
+        const AT: &'static str = "node bin_expr found here";
+        const SHOW_ALSO_L: &'static str = "node l found here";
+        const SHOW_ALSO_R: &'static str = "node r found here";
+        const EXTRA_INFO: &'static str = "some hopefully useful extra info";
+
+        let irritations = VexTest::new("arg-combinations")
+            .with_scriptlet(
+                format!("vexes/{VEX_NAME}.star"),
+                formatdoc! {r#"
+                    def init():
+                        vex.language('rust')
+                        vex.query('(binary_expression left: (integer_literal) @l right: (integer_literal) @r) @bin_expr')
+                        vex.observe('match', on_match)
+
+                    def on_match(event):
+                        bin_expr = event.captures['bin_expr']
+                        l = event.captures['l']
+                        r = event.captures['r']
+
+                        at = (bin_expr, '{AT}')
+                        show_also = [(l, '{SHOW_ALSO_L}'), (r, '{SHOW_ALSO_R}')]
+                        extra_info = '{EXTRA_INFO}'
+
+                        vex.warn('test-0')
+                        vex.warn('test-1', extra_info=extra_info)
+                        vex.warn('test-2', at=at)
+                        vex.warn('test-3', at=at, show_also=show_also)
+                        vex.warn('test-4', at=at, show_also=show_also, extra_info=extra_info)
+                "#},
+            )
+            .with_source_file(
+                "main.rs",
+                indoc! {r#"
+                    fn main() {
+                        let x = 1 + 2;
+                        println!("{x}");
+                    }
+                .into_iter()
+                "#},
+            )
+            .try_run()
+            .unwrap()
+            .into_iter()
+            .map(|irr| irr.to_string())
+            .collect::<Vec<_>>();
+        assert_eq!(irritations.len(), 5);
+
+        println!("{irritations:?}");
+
+        let assert_contains = |irritation: &str, strings: &[&'static str]| {
+            [VEX_NAME]
+                .as_ref()
+                .into_iter()
+                .chain(strings)
+                .for_each(|string| {
+                    assert!(
+                        irritation.contains(string),
+                        "could not find {string} in {irritation}"
+                    )
+                })
+        };
+        assert_contains(&irritations[0], &[VEX_NAME, "test-0"]);
+        assert_contains(&irritations[1], &[VEX_NAME, "test-1", EXTRA_INFO]);
+        assert_contains(&irritations[2], &[VEX_NAME, "test-2", AT]);
+        assert_contains(
+            &irritations[3],
+            &[VEX_NAME, "test-3", AT, SHOW_ALSO_L, SHOW_ALSO_R],
+        );
+        assert_contains(
+            &irritations[4],
+            &[VEX_NAME, "test-4", AT, SHOW_ALSO_L, SHOW_ALSO_R, EXTRA_INFO],
+        );
+
+        assert_yaml_snapshot!(irritations);
+    }
+
+    #[test]
+    fn warn_invalid() {
+        const VEX_NAME: &'static str = "name_of_vex";
+        const SHOW_ALSO_L: &'static str = "node l found here";
+        const SHOW_ALSO_R: &'static str = "node r found here";
+        VexTest::new("show-also-without-at")
+            .with_scriptlet(
+                format!("vexes/{VEX_NAME}.star"),
+                formatdoc! {r#"
+                    def init():
+                        vex.language('rust')
+                        vex.query('(binary_expression left: (integer_literal) @l right: (integer_literal) @r) @bin_expr')
+                        vex.observe('match', on_match)
+
+                    def on_match(event):
+                        l = event.captures['l']
+                        r = event.captures['r']
+
+                        show_also = [(l, '{SHOW_ALSO_L}'), (r, '{SHOW_ALSO_R}')]
+
+                        vex.warn('test-2', show_also=show_also)
+                "#},
+            )
+            .with_source_file(
+                "src/main.rs",
+                indoc! {r#"
+                    fn main() {
+                        let x = 1 + 2;
+                        println!("{x}");
+                    }
+                .into_iter()
+                "#},
+            )
+            .returns_error("cannot display `show_also` without an `at` argument")
+    }
+
+    #[test]
+    fn warn_sorting() {
+        const VEX_1_NAME: &'static str = "vex_1";
+        const VEX_2_NAME: &'static str = "vex_2";
+        const AT: &'static str = "node bin_expr found here";
+        const SHOW_ALSO_L: &'static str = "node l found here";
+        const SHOW_ALSO_R: &'static str = "node r found here";
+        const EXTRA_INFO: &'static str = "some hopefully useful extra info";
+
+        let vex_source = formatdoc! {r#"
+            def init():
+                vex.language('rust')
+                vex.query('(binary_expression left: (integer_literal) @l right: (integer_literal) @r) @bin_expr')
+                vex.observe('match', on_match)
+
+            def on_match(event):
+                bin_expr = event.captures['bin_expr']
+                l = event.captures['l']
+                r = event.captures['r']
+
+                at = (bin_expr, '{AT}')
+                show_also = [(l, '{SHOW_ALSO_L}'), (r, '{SHOW_ALSO_R}')]
+                extra_info = '{EXTRA_INFO}'
+
+                # Emit warnings in opposite order to expected.
+                vex.warn('message-six', at=(bin_expr, 'bin_expr'), show_also=[(r, 'r')])
+                vex.warn('message-four', at=(bin_expr, 'bin_expr'), show_also=[(l, 'l')])
+                vex.warn('message-seven', at=(bin_expr, 'bin_expr'), show_also=[(r, 'r')], extra_info=extra_info)
+                vex.warn('message-five', at=(bin_expr, 'bin_expr'), show_also=[(l, 'l')], extra_info=extra_info)
+                vex.warn('message-eight', at=(r, 'r'))
+                vex.warn('message-three', at=(l, 'l'))
+                vex.warn('message-one')
+                vex.warn('message-two')
+        "#};
+        let irritations = VexTest::new("many-origins")
+            .with_scriptlet(format!("vexes/{VEX_2_NAME}.star"), &vex_source)
+            .with_scriptlet(format!("vexes/{VEX_1_NAME}.star"), &vex_source)
+            .with_source_file(
+                "src/main.rs",
+                indoc! {r#"
+                    fn main() {
+                        let x = 1 + 2;
+                        println!("{x}");
+                    }
+                .into_iter()
+                "#},
+            )
+            .try_run()
+            .unwrap()
+            .into_iter()
+            .map(|irr| irr.to_string())
+            .collect::<Vec<_>>();
+
+        assert_eq!(irritations.len(), 8 * 2);
+
+        let text_numbers = [
+            "one", "two", "three", "four", "five", "six", "seven", "eight",
+        ];
+        let text_number_indices = text_numbers
+            .iter()
+            .map(|text_num| irritations.iter().position(|irr| irr.contains(text_num)))
+            .map(Option::unwrap)
+            .collect::<Vec<_>>();
+        text_number_indices
+            .iter()
+            .scan(None, |prev, e| {
+                let ret = prev.iter().map(|prev| *prev < e).next().unwrap_or(true);
+                *prev = Some(e);
+                Some(ret)
+            })
+            .for_each(|lt| {
+                assert!(
+                    lt,
+                    "indices do not monotonically increase: {text_number_indices:?}"
+                )
+            });
+
+        assert_yaml_snapshot!(irritations);
     }
 }

--- a/src/scriptlets/app_object.rs
+++ b/src/scriptlets/app_object.rs
@@ -155,11 +155,11 @@ mod test {
 
     #[test]
     fn warn_valid() {
-        const VEX_NAME: &'static str = "name_of_vex";
-        const AT: &'static str = "node bin_expr found here";
-        const SHOW_ALSO_L: &'static str = "node l found here";
-        const SHOW_ALSO_R: &'static str = "node r found here";
-        const EXTRA_INFO: &'static str = "some hopefully useful extra info";
+        const VEX_NAME: &str = "name_of_vex";
+        const AT: &str = "node bin_expr found here";
+        const SHOW_ALSO_L: &str = "node l found here";
+        const SHOW_ALSO_R: &str = "node r found here";
+        const EXTRA_INFO: &str = "some hopefully useful extra info";
 
         let irritations = VexTest::new("arg-combinations")
             .with_scriptlet(
@@ -205,10 +205,10 @@ mod test {
 
         println!("{irritations:?}");
 
-        let assert_contains = |irritation: &str, strings: &[&'static str]| {
+        let assert_contains = |irritation: &str, strings: &[&str]| {
             [VEX_NAME]
                 .as_ref()
-                .into_iter()
+                .iter()
                 .chain(strings)
                 .for_each(|string| {
                     assert!(
@@ -234,9 +234,9 @@ mod test {
 
     #[test]
     fn warn_invalid() {
-        const VEX_NAME: &'static str = "name_of_vex";
-        const SHOW_ALSO_L: &'static str = "node l found here";
-        const SHOW_ALSO_R: &'static str = "node r found here";
+        const VEX_NAME: &str = "name_of_vex";
+        const SHOW_ALSO_L: &str = "node l found here";
+        const SHOW_ALSO_R: &str = "node r found here";
         VexTest::new("show-also-without-at")
             .with_scriptlet(
                 format!("vexes/{VEX_NAME}.star"),
@@ -270,12 +270,12 @@ mod test {
 
     #[test]
     fn warn_sorting() {
-        const VEX_1_NAME: &'static str = "vex_1";
-        const VEX_2_NAME: &'static str = "vex_2";
-        const AT: &'static str = "node bin_expr found here";
-        const SHOW_ALSO_L: &'static str = "node l found here";
-        const SHOW_ALSO_R: &'static str = "node r found here";
-        const EXTRA_INFO: &'static str = "some hopefully useful extra info";
+        const VEX_1_NAME: &str = "vex_1";
+        const VEX_2_NAME: &str = "vex_2";
+        const AT: &str = "node bin_expr found here";
+        const SHOW_ALSO_L: &str = "node l found here";
+        const SHOW_ALSO_R: &str = "node r found here";
+        const EXTRA_INFO: &str = "some hopefully useful extra info";
 
         let vex_source = formatdoc! {r#"
             def init():

--- a/src/scriptlets/node.rs
+++ b/src/scriptlets/node.rs
@@ -23,7 +23,7 @@ pub struct Node<'v> {
     ts_node: &'v TSNode<'v>,
 
     #[allocative(skip)]
-    source_file: &'v SourceFile,
+    pub source_file: &'v SourceFile,
 }
 
 unsafe impl<'v> Trace<'v> for Node<'v> {

--- a/src/scriptlets/observers.rs
+++ b/src/scriptlets/observers.rs
@@ -42,7 +42,6 @@ pub trait Observer<'v> {
 
     fn function(&self) -> &OwnedFrozenValue;
 
-    #[must_use]
     fn handle(
         &'v self,
         module: &'v Module,

--- a/src/scriptlets/observers.rs
+++ b/src/scriptlets/observers.rs
@@ -11,11 +11,13 @@ use tree_sitter::Query;
 
 use crate::{
     error::Error,
+    irritation::Irritation,
     result::Result,
     scriptlets::{
         action::Action,
-        event::Event,
-        event::{CloseFileEvent, CloseProjectEvent, MatchEvent, OpenFileEvent, OpenProjectEvent},
+        event::{
+            CloseFileEvent, CloseProjectEvent, Event, MatchEvent, OpenFileEvent, OpenProjectEvent,
+        },
         extra_data::InvocationData,
         print_handler::PrintHandler,
     },
@@ -40,21 +42,31 @@ pub trait Observer<'v> {
 
     fn function(&self) -> &OwnedFrozenValue;
 
-    fn handle(&'v self, module: &'v Module, _path: &PrettyPath, event: Self::Event) -> Result<()>
+    #[must_use]
+    fn handle(
+        &'v self,
+        module: &'v Module,
+        path: &PrettyPath,
+        event: Self::Event,
+    ) -> Result<Vec<Irritation>>
     where
         Self::Event: StarlarkValue<'v> + AllocValue<'v> + Event,
     {
-        let extra = InvocationData::new(Action::Vexing(<Self::Event as Event>::TYPE));
+        let extra = InvocationData::new(Action::Vexing(<Self::Event as Event>::TYPE), path.dupe());
 
-        let mut eval = Evaluator::new(module);
-        eval.set_print_handler(&PrintHandler);
-        extra.insert_into(&mut eval);
+        {
+            let mut eval = Evaluator::new(module);
+            eval.set_print_handler(&PrintHandler);
+            extra.insert_into(&mut eval);
 
-        let func = self.function().value(); // TODO(kcza): check thread safety! Can this unfrozen
-                                            // function mutate upvalues if it is a closure?
-        eval.eval_function(func, &[module.heap().alloc(event)], &[])
-            .map_err(Error::starlark)?;
-        Ok(())
+            let func = self.function().value(); // TODO(kcza): check thread safety! Can this unfrozen
+                                                // function mutate upvalues if it is a closure?
+            eval.eval_function(func, &[module.heap().alloc(event)], &[])
+                .map_err(Error::starlark)?;
+        }
+
+        let irritations = extra.irritations.into_inner().expect("lock poisoned");
+        Ok(irritations)
     }
 }
 

--- a/src/scriptlets/scriptlet.rs
+++ b/src/scriptlets/scriptlet.rs
@@ -78,7 +78,7 @@ impl PreinitingScriptlet {
         let preinited_module = {
             let module = Module::new();
             {
-                let extra = InvocationData::new(Action::Preiniting);
+                let extra = InvocationData::new(Action::Preiniting, path.pretty_path.dupe());
                 let mut eval = Evaluator::new(&module);
                 eval.set_loader(&cache);
                 eval.set_print_handler(&PrintHandler);
@@ -145,7 +145,7 @@ impl InitingScriptlet {
             let module = Module::new();
             ObserverDataBuilder::new(path.pretty_path.dupe()).insert_into(&module);
             {
-                let extra = InvocationData::new(Action::Initing);
+                let extra = InvocationData::new(Action::Initing, path.pretty_path.dupe());
                 let mut eval = Evaluator::new(&module);
                 eval.set_print_handler(&PrintHandler);
                 extra.insert_into(&mut eval);

--- a/src/scriptlets/snapshots/vex__scriptlets__app_object__test__warn_sorting.snap
+++ b/src/scriptlets/snapshots/vex__scriptlets__app_object__test__warn_sorting.snap
@@ -1,0 +1,20 @@
+---
+source: src/scriptlets/app_object.rs
+expression: irritations
+---
+- "warning[vex_1]: message-one"
+- "warning[vex_1]: message-two"
+- "warning[vex_2]: message-one"
+- "warning[vex_2]: message-two"
+- "warning[vex_1]: message-three\n --> src/main.rs:2:17\n  |\n2 |         let x = 1 + 2;\n  |                 - l\n  |"
+- "warning[vex_2]: message-three\n --> src/main.rs:2:17\n  |\n2 |         let x = 1 + 2;\n  |                 - l\n  |"
+- "warning[vex_1]: message-four\n --> src/main.rs:2:17\n  |\n2 |         let x = 1 + 2;\n  |                 ----- bin_expr\n  |                 - info: l\n  |"
+- "warning[vex_1]: message-five\n --> src/main.rs:2:17\n  |\n2 |         let x = 1 + 2;\n  |                 ----- bin_expr\n  |                 - info: l\n  |\n  = info: some hopefully useful extra info"
+- "warning[vex_1]: message-six\n --> src/main.rs:2:17\n  |\n2 |         let x = 1 + 2;\n  |                 ----- bin_expr\n  |                     - info: r\n  |"
+- "warning[vex_1]: message-seven\n --> src/main.rs:2:17\n  |\n2 |         let x = 1 + 2;\n  |                 ----- bin_expr\n  |                     - info: r\n  |\n  = info: some hopefully useful extra info"
+- "warning[vex_2]: message-four\n --> src/main.rs:2:17\n  |\n2 |         let x = 1 + 2;\n  |                 ----- bin_expr\n  |                 - info: l\n  |"
+- "warning[vex_2]: message-five\n --> src/main.rs:2:17\n  |\n2 |         let x = 1 + 2;\n  |                 ----- bin_expr\n  |                 - info: l\n  |\n  = info: some hopefully useful extra info"
+- "warning[vex_2]: message-six\n --> src/main.rs:2:17\n  |\n2 |         let x = 1 + 2;\n  |                 ----- bin_expr\n  |                     - info: r\n  |"
+- "warning[vex_2]: message-seven\n --> src/main.rs:2:17\n  |\n2 |         let x = 1 + 2;\n  |                 ----- bin_expr\n  |                     - info: r\n  |\n  = info: some hopefully useful extra info"
+- "warning[vex_1]: message-eight\n --> src/main.rs:2:21\n  |\n2 |         let x = 1 + 2;\n  |                     - r\n  |"
+- "warning[vex_2]: message-eight\n --> src/main.rs:2:21\n  |\n2 |         let x = 1 + 2;\n  |                     - r\n  |"

--- a/src/scriptlets/snapshots/vex__scriptlets__app_object__test__warn_valid.snap
+++ b/src/scriptlets/snapshots/vex__scriptlets__app_object__test__warn_valid.snap
@@ -1,0 +1,9 @@
+---
+source: src/scriptlets/app_object.rs
+expression: irritations
+---
+- "warning[name_of_vex]: test-0"
+- "warning[name_of_vex]: test-1\n = info: some hopefully useful extra info"
+- "warning[name_of_vex]: test-2\n --> main.rs:2:17\n  |\n2 |         let x = 1 + 2;\n  |                 ----- node bin_expr found here\n  |"
+- "warning[name_of_vex]: test-3\n --> main.rs:2:17\n  |\n2 |         let x = 1 + 2;\n  |                 ----- node bin_expr found here\n  |                 - info: node l found here\n  |                     - info: node r found here\n  |"
+- "warning[name_of_vex]: test-4\n --> main.rs:2:17\n  |\n2 |         let x = 1 + 2;\n  |                 ----- node bin_expr found here\n  |                 - info: node l found here\n  |                     - info: node r found here\n  |\n  = info: some hopefully useful extra info"

--- a/src/source_path.rs
+++ b/src/source_path.rs
@@ -25,9 +25,7 @@ impl SourcePath {
         Self {
             abs_path: path.into(),
             pretty_path: PrettyPath::new(
-                path.strip_prefix(base_dir)
-                    .expect("path not in base dir")
-                    .into(),
+                path.strip_prefix(base_dir).expect("path not in base dir"),
             ),
         }
     }
@@ -119,7 +117,7 @@ impl PrettyPath {
 
 impl From<&str> for PrettyPath {
     fn from(value: &str) -> Self {
-        Self::new(Utf8Path::new(value).into())
+        Self::new(Utf8Path::new(value))
     }
 }
 

--- a/src/source_path.rs
+++ b/src/source_path.rs
@@ -3,12 +3,13 @@ use std::{fmt::Display, ops::Deref, sync::Arc};
 use allocative::Allocative;
 use camino::Utf8Path;
 use dupe::Dupe;
+use serde::Serialize;
 use starlark::{
     environment::{Methods, MethodsBuilder, MethodsStatic},
     starlark_module, starlark_simple_value,
     values::{list::AllocList, Demand, Heap, StarlarkValue, Value, ValueError},
 };
-use starlark_derive::{starlark_value, NoSerialize, ProvidesStaticType};
+use starlark_derive::{starlark_value, ProvidesStaticType};
 
 #[derive(Clone, Debug, PartialEq, Eq, Dupe)]
 pub struct SourcePath {
@@ -62,7 +63,7 @@ impl Display for SourcePath {
     Ord,
     Hash,
     Allocative,
-    NoSerialize,
+    Serialize,
     ProvidesStaticType,
 )]
 pub struct PrettyPath(#[allocative(skip)] Arc<Utf8Path>);

--- a/src/source_path.rs
+++ b/src/source_path.rs
@@ -1,5 +1,8 @@
 use std::{fmt::Display, ops::Deref, sync::Arc};
 
+#[cfg(target_os = "windows")]
+use std::path;
+
 use allocative::Allocative;
 use camino::Utf8Path;
 use dupe::Dupe;
@@ -21,7 +24,7 @@ impl SourcePath {
     pub fn new(path: &Utf8Path, base_dir: &Utf8Path) -> Self {
         Self {
             abs_path: path.into(),
-            pretty_path: PrettyPath(
+            pretty_path: PrettyPath::new(
                 path.strip_prefix(base_dir)
                     .expect("path not in base dir")
                     .into(),
@@ -66,20 +69,34 @@ impl Display for SourcePath {
     Serialize,
     ProvidesStaticType,
 )]
-pub struct PrettyPath(#[allocative(skip)] Arc<Utf8Path>);
+pub struct PrettyPath {
+    #[allocative(skip)]
+    path: Arc<Utf8Path>,
+
+    #[cfg(target_os = "windows")]
+    sanitised_path: Arc<str>,
+}
 starlark_simple_value!(PrettyPath);
 
 impl PrettyPath {
     pub fn new(path: &Utf8Path) -> Self {
-        Self(Arc::from(path))
+        Self {
+            path: Arc::from(path),
+
+            #[cfg(target_os = "windows")]
+            sanitised_path: path.as_str().replace(path::MAIN_SEPARATOR, "/").into(),
+        }
     }
 
     pub fn as_str(&self) -> &str {
-        self.0.as_str()
+        #[cfg(not(target_os = "windows"))]
+        return self.path.as_str();
+        #[cfg(target_os = "windows")]
+        return self.sanitised_path.as_str();
     }
 
     pub fn len(&self) -> usize {
-        self.0.components().count()
+        self.path.components().count()
     }
 
     #[starlark_module]
@@ -93,25 +110,22 @@ impl PrettyPath {
                 return Ok(this == other);
             }
 
-            if let Some(other) = other.unpack_str() {
-                let this_str = this.0.as_str();
-                return Ok(this_str == other || this_str.replace('/', "\\") == other);
-            }
-
-            Ok(false)
+            Ok(other
+                .unpack_str()
+                .is_some_and(|other| this.as_str() == other))
         }
     }
 }
 
 impl From<&str> for PrettyPath {
     fn from(value: &str) -> Self {
-        Self(Utf8Path::new(value).into())
+        Self::new(Utf8Path::new(value).into())
     }
 }
 
 impl AsRef<Utf8Path> for PrettyPath {
     fn as_ref(&self) -> &Utf8Path {
-        &self.0
+        &self.path
     }
 }
 
@@ -119,13 +133,16 @@ impl Deref for PrettyPath {
     type Target = Utf8Path;
 
     fn deref(&self) -> &Self::Target {
-        self.0.as_ref()
+        self.path.as_ref()
     }
 }
 
 impl Display for PrettyPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.0.fmt(f)
+        #[cfg(not(target_os = "windows"))]
+        return self.path.fmt(f);
+        #[cfg(target_os = "windows")]
+        return self.sanitised_path.fmt(f);
     }
 }
 
@@ -352,11 +369,9 @@ mod test {
     fn matches() {
         PathTest::new("matches").path("src/main.rs").run(indoc! {r#"
             check['true'](path.matches("src/main.rs"))
-            check['true'](path.matches("src\\main.rs"))
             check['false'](path.matches(None))
             check['false'](path.matches(''))
             check['false'](path.matches("src/lib.rs"))
-            check['false'](path.matches("src\\lib.rs"))
         "#});
     }
 

--- a/src/vextest.rs
+++ b/src/vextest.rs
@@ -10,8 +10,7 @@ use indoc::indoc;
 use regex::Regex;
 
 use crate::{
-    cli::MaxProblems, context::Context, irritation::Irritation, result::Result,
-    scriptlets::PreinitingStore,
+    cli::MaxProblems, context::Context, result::Result, scriptlets::PreinitingStore, RunData,
 };
 
 pub struct VexTest<'s> {
@@ -91,22 +90,11 @@ impl<'s> VexTest<'s> {
     }
 
     pub fn assert_irritation_free(self) {
-        assert_eq!(self.try_run().unwrap(), &[], "irritations returned!");
-    }
-
-    #[allow(unused)]
-    pub fn returns_irritations(self, irritations: Vec<IrritationMatch>) {
-        self.try_run()
-            .unwrap()
-            .into_iter()
-            .zip(irritations)
-            .enumerate()
-            .for_each(|(i, (irritation, matcher))| {
-                assert!(
-                    matcher.matches(&irritation),
-                    "irritation {i} incorrect, expected {matcher:?}, got {irritation:?}"
-                )
-            });
+        assert_eq!(
+            self.try_run().unwrap().into_irritations(),
+            &[],
+            "irritations returned!"
+        );
     }
 
     pub fn returns_error(self, message: impl Into<Cow<'static, str>>) {
@@ -119,7 +107,7 @@ impl<'s> VexTest<'s> {
         );
     }
 
-    pub fn try_run(mut self) -> Result<Vec<Irritation>> {
+    pub fn try_run(mut self) -> Result<RunData> {
         self.setup();
 
         let root_dir = tempfile::tempdir().unwrap();
@@ -225,19 +213,4 @@ impl<'s> VexTest<'s> {
 
         check
     "#};
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct IrritationMatch {
-    vex_id: Cow<'static, str>,
-    message: Cow<'static, str>,
-    start_byte: usize,
-    end_byte: usize,
-    path: Utf8PathBuf,
-}
-
-impl IrritationMatch {
-    pub fn matches(&self, _irritation: &Irritation) -> bool {
-        todo!();
-    }
 }


### PR DESCRIPTION
This PR implements the `vex.warn` function, which has API:
```python
vex.warn(
    message,
    [at=(Node, message_at_node)]
    [show_also=[(Node, message_at_node)]]
    [extra_info=info]
)
```
