### PR TITLE
Fix check id parsing

### DIFF
--- a/src/check_id.rs
+++ b/src/check_id.rs
@@ -1,0 +1,58 @@
+use std::fmt::Display;
+
+use dupe::Dupe;
+
+use crate::{error::Error, result::Result, source_path::PrettyPath};
+
+#[derive(Debug)]
+pub struct CheckId<'s>(&'s str);
+
+impl<'s> CheckId<'s> {
+    pub fn as_str(&self) -> &'s str {
+        self.0
+    }
+}
+
+impl<'s> AsRef<str> for CheckId<'s> {
+    fn as_ref(&self) -> &str {
+        self.0
+    }
+}
+
+impl<'s> TryFrom<&'s PrettyPath> for CheckId<'s> {
+    type Error = Error;
+
+    fn try_from(path: &'s PrettyPath) -> Result<Self> {
+        Ok(Self(
+            path.as_str()
+                .strip_suffix(".star")
+                .ok_or_else(|| Error::NotACheckPath(path.dupe()))?,
+        ))
+    }
+}
+
+impl Display for CheckId<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.as_str().fmt(f)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn try_from_valid() {
+        let path = PrettyPath::from("foo/bar.star");
+        assert_eq!(CheckId::try_from(&path).unwrap().as_str(), "foo/bar");
+    }
+
+    #[test]
+    fn try_from_invalid() {
+        let path = PrettyPath::from("nope.avi");
+        assert_eq!(
+            CheckId::try_from(&path).unwrap_err().to_string(),
+            "nope.avi is not a check path"
+        );
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -67,6 +67,9 @@ pub enum Error {
     #[error("cannot find vexes directory at {0}")]
     NoVexesDir(Utf8PathBuf),
 
+    #[error("{0} is not a check path")]
+    NotACheckPath(PrettyPath),
+
     #[error("{0}")]
     ParseInt(#[from] num::ParseIntError),
 

--- a/src/irritation.rs
+++ b/src/irritation.rs
@@ -5,7 +5,7 @@ use annotate_snippets::{Annotation, AnnotationType, Slice, Snippet, SourceAnnota
 use dupe::Dupe;
 use serde::Serialize;
 
-use crate::{logger, scriptlets::Node, source_path::PrettyPath};
+use crate::{check_id::CheckId, logger, scriptlets::Node, source_path::PrettyPath};
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Allocative, Serialize)]
 #[non_exhaustive]
@@ -102,7 +102,11 @@ impl<'v> IrritationRenderer<'v> {
             .map(|source| source.0.source_file.path.pretty_path.as_str());
         let snippet = Snippet {
             title: Some(Annotation {
-                id: Some(vex_path.file_stem().expect("vex has no file stem")),
+                id: Some(
+                    CheckId::try_from(&vex_path)
+                        .expect("internal error: failed to make CheckId")
+                        .as_str(),
+                ),
                 label: Some(message),
                 annotation_type: AnnotationType::Warning,
             }),

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@
 #[macro_use]
 extern crate pretty_assertions;
 
+mod check_id;
 mod cli;
 mod context;
 mod error;
@@ -36,6 +37,7 @@ use strum::IntoEnumIterator;
 use tree_sitter::QueryCursor;
 
 use crate::{
+    check_id::CheckId,
     cli::{Args, CheckCmd, Command},
     context::Context,
     error::{Error, IOAction},
@@ -84,7 +86,7 @@ fn list(list_args: ListCmd) -> Result<()> {
             let store = PreinitingStore::new(&ctx)?.preinit()?;
             store
                 .vexes()
-                .flat_map(|vex| vex.path.pretty_path.file_stem())
+                .flat_map(|vex| CheckId::try_from(&vex.path.pretty_path))
                 .for_each(|id| println!("{}", id));
         }
         ToList::Languages => SupportedLanguage::iter().for_each(|lang| println!("{}", lang)),


### PR DESCRIPTION
Previously, check IDs did not respect sub-directories, that is—
```
vexes/foo.star     # had id `foo`
vexes/bar/foo.star # had id `foo`
```
This PR adds the path within the vexes directory into the id, that is—
```
vexes/foo.star     # has id `foo`
vexes/bar/foo.star # has id `bar/foo`
