### PR TITLE
Improve `init` success message

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -21,6 +21,8 @@ pub struct Context {
     pub manifest: Manifest,
 }
 
+pub const EXAMPLE_VEX_FILE: &str = "example.star";
+
 impl Context {
     pub fn acquire() -> Result<Self> {
         let (project_root, raw_data) = Manifest::acquire_content()?;
@@ -56,7 +58,7 @@ impl Context {
 
         let example_vex_path = Utf8PathBuf::from(project_root)
             .join(QueriesDir::default().as_str())
-            .join("example.star");
+            .join(EXAMPLE_VEX_FILE);
         const EXAMPLE_VEX_CONTENT: &str = indoc! {r#"
             def init():
                 # First add callbacks for vex's top-level events.

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,7 @@ use camino::{Utf8Path, Utf8PathBuf};
 use clap::Parser as _;
 use cli::{ListCmd, MaxProblems, ParseCmd, ToList};
 use dupe::Dupe;
+use indoc::printdoc;
 use lazy_static::lazy_static;
 use log::{info, log_enabled, trace, warn};
 use owo_colors::{OwoColorize, Stream, Style};
@@ -376,8 +377,12 @@ fn init() -> Result<()> {
     })?)?;
     Context::init(cwd)?;
     let queries_dir = Context::acquire()?.manifest.queries_dir;
-    println!(
-        "{}: vex initialised\nnow add style rules in ./{}/\nsee ./{}/{EXAMPLE_VEX_FILE} for how",
+    printdoc!(
+        "
+            {}: vex initialised
+            now add style rules in ./{}/
+            for an example, open ./{}/{EXAMPLE_VEX_FILE}
+        ",
         "success".if_supports_color(Stream::Stdout, |text| text.style(*SUCCESS_STYLE)),
         queries_dir.as_str(),
         queries_dir.as_str(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ use tree_sitter::QueryCursor;
 use crate::{
     check_id::CheckId,
     cli::{Args, CheckCmd, Command},
-    context::Context,
+    context::{Context, EXAMPLE_VEX_FILE},
     error::{Error, IOAction},
     irritation::Irritation,
     plural::Plural,
@@ -377,8 +377,9 @@ fn init() -> Result<()> {
     Context::init(cwd)?;
     let queries_dir = Context::acquire()?.manifest.queries_dir;
     println!(
-        "{}: vex initialised, now add style rules in ./{}/",
+        "{}: vex initialised\nnow add style rules in ./{}/\nsee ./{}/{EXAMPLE_VEX_FILE} for how",
         "success".if_supports_color(Stream::Stdout, |text| text.style(*SUCCESS_STYLE)),
+        queries_dir.as_str(),
         queries_dir.as_str(),
     );
     Ok(())


### PR DESCRIPTION
The current success message indicates where to put vexes but not how to write them. This PR adds an sentence to the success message to point the user to the auto-generated example vex
