### PR TITLE
Generalise empty-query check

### DIFF
--- a/src/scriptlets/app_object.rs
+++ b/src/scriptlets/app_object.rs
@@ -62,9 +62,6 @@ impl AppObject {
             let ret_data = UnfrozenRetainedData::get_from(eval.module());
             let language = language.parse::<SupportedLanguage>()?;
             let query = {
-                if query.is_empty() {
-                    return Err(Error::EmptyQuery.into());
-                }
                 let temp_data = TempData::get_from(eval);
                 temp_data.query_cache.get(language, query)?
             };

--- a/src/scriptlets/query_cache.rs
+++ b/src/scriptlets/query_cache.rs
@@ -8,7 +8,7 @@ use starlark::{
 };
 use tree_sitter::Query;
 
-use crate::{result::Result, supported_language::SupportedLanguage};
+use crate::{error::Error, result::Result, supported_language::SupportedLanguage};
 
 #[derive(Clone, Debug, Allocative)]
 pub struct QueryCache {
@@ -40,6 +40,10 @@ impl QueryCache {
         }
 
         let query = Arc::new(Query::new(language.ts_language(), &raw_query)?);
+        if query.pattern_count() == 0 {
+            return Err(Error::EmptyQuery);
+        }
+
         self.cache
             .borrow_mut()
             .insert((language, query_hash), CachedQuery(query.dupe()));

--- a/src/trigger.rs
+++ b/src/trigger.rs
@@ -246,6 +246,25 @@ mod test {
                 "#},
             )
             .returns_error(r"query is empty");
+        VexTest::new("comment only")
+            .with_scriptlet(
+                "vexes/test.star",
+                indoc! {r#"
+                    def init():
+                        vex.observe('open_project', on_open_project)
+
+                    def on_open_project(event):
+                        vex.search(
+                            'rust',
+                            '; this query contains nothing!',
+                            on_match,
+                        )
+
+                    def on_match(event):
+                        pass
+                "#},
+            )
+            .returns_error(r"query is empty");
         VexTest::new("syntax-error")
             .with_scriptlet(
                 "vexes/test.star",


### PR DESCRIPTION
This PR generalises the empty query check to also catch queries which consist entirely of comments, spaces and line--breaks
