### PR TITLE
Allow base associations to be overridden

### DIFF
--- a/src/associations.rs
+++ b/src/associations.rs
@@ -29,10 +29,9 @@ impl Associations {
             .into_iter()
             .map(|(pattern, language)| {
                 let file_patterns = vec![RawFilePattern::new(pattern).compile().unwrap()];
-                let in_base = true;
                 Association {
                     file_patterns,
-                    in_base,
+                    in_base: true,
                     language,
                 }
             })

--- a/src/associations.rs
+++ b/src/associations.rs
@@ -169,6 +169,32 @@ mod test {
     }
 
     #[test]
+    fn nonambiguous_overlap() {
+        let associations = {
+            let mut associations = Associations::base();
+            associations.insert(
+                vec![RawFilePattern::new("*.rust-file").compile().unwrap()],
+                SupportedLanguage::Rust,
+            );
+            associations.insert(
+                vec![RawFilePattern::new("rust-files/*").compile().unwrap()],
+                SupportedLanguage::Rust,
+            );
+            associations
+        };
+        assert_eq!(
+            associations
+                .get_language(&SourcePath::new_in(
+                    "rust-files/some.rust-file".into(),
+                    "".into()
+                ))
+                .unwrap()
+                .unwrap(),
+            SupportedLanguage::Rust,
+        );
+    }
+
+    #[test]
     fn from_manifest() {
         let tempdir = tempfile::tempdir().unwrap();
         let tempdir_path = Utf8PathBuf::try_from(tempdir.path().to_owned()).unwrap();


### PR DESCRIPTION
Currently, base associations cannot be overridden. The rationale here was that no reasonable project would use associate any of the standard file extensions with another supported language, hence not supporting this was intended as a reasonable prod for users to fix their weird file names. However, with the addition of C++ support and its occasionally-ambiguous file extensions for both [source][cpp-source-file-naming] and [header][cpp-header-file-naming] files, it will become necessary to override the defaults.

This PR allows user-provided associations to override base ones, but user-provided association clashes are still reported as errors

[cpp-source-file-naming]: https://isocpp.org/wiki/faq/coding-standards#src-file-ext
[cpp-header-file-naming]: https://isocpp.org/wiki/faq/coding-standards#hdr-file-ext
