### PR TITLE
Add ignore marker support

### DIFF
--- a/src/ignore_markers.rs
+++ b/src/ignore_markers.rs
@@ -53,12 +53,14 @@ mod test {
 
     #[test]
     fn ignore_markers() {
-        let mut ignore_markers_builder = IgnoreMarkers::builder();
-        ignore_markers_builder.add(3..10);
-        ignore_markers_builder.add(4..9);
-        ignore_markers_builder.add(4..10);
-        ignore_markers_builder.add(11..13);
-        let ignore_markers = ignore_markers_builder.build();
+        let ignore_markers = {
+            let mut builder = IgnoreMarkers::builder();
+            builder.add(3..10);
+            builder.add(4..9);
+            builder.add(4..10);
+            builder.add(11..13);
+            builder.build()
+        };
 
         let tests = [
             (1, false),

--- a/src/ignore_markers.rs
+++ b/src/ignore_markers.rs
@@ -1,41 +1,44 @@
 use std::ops::Range;
 
-pub struct Ignores {
-    ignores: Vec<Range<usize>>,
+#[derive(Debug)]
+pub struct IgnoreMarkers {
+    ignore_ranges: Vec<Range<usize>>,
 }
 
-impl Ignores {
-    pub fn builder() -> IgnoresBuilder {
-        IgnoresBuilder::new()
+impl IgnoreMarkers {
+    pub fn builder() -> IgnoreMarkersBuilder {
+        IgnoreMarkersBuilder::new()
     }
 
     pub fn contains(&self, index: usize) -> bool {
-        let possible_ignores_end = self.ignores.partition_point(|range| range.start <= index);
-        self.ignores[..possible_ignores_end]
+        let possible_ignores_end = self
+            .ignore_ranges
+            .partition_point(|range| range.start <= index);
+        self.ignore_ranges[..possible_ignores_end]
             .iter()
             .any(|range| index < range.end)
     }
 }
 
-pub struct IgnoresBuilder {
-    ignores: Vec<Range<usize>>,
+pub struct IgnoreMarkersBuilder {
+    ignore_ranges: Vec<Range<usize>>,
 }
 
-impl IgnoresBuilder {
+impl IgnoreMarkersBuilder {
     pub fn new() -> Self {
         Self {
-            ignores: Vec::new(),
+            ignore_ranges: Vec::new(),
         }
     }
 
     pub fn add(&mut self, range: Range<usize>) {
-        self.ignores.push(range)
+        self.ignore_ranges.push(range)
     }
 
-    pub fn build(self) -> Ignores {
-        let Self { mut ignores } = self;
-        ignores.sort_by_key(|range| (range.start, -(range.end as i64)));
-        Ignores { ignores }
+    pub fn build(self) -> IgnoreMarkers {
+        let Self { mut ignore_ranges } = self;
+        ignore_ranges.sort_by_key(|range| (range.start, -(range.end as i64)));
+        IgnoreMarkers { ignore_ranges }
     }
 }
 
@@ -45,7 +48,7 @@ mod test {
 
     #[test]
     fn ignores() {
-        let mut ignores_builder = Ignores::builder();
+        let mut ignores_builder = IgnoreMarkers::builder();
         ignores_builder.add(3..10);
         ignores_builder.add(4..9);
         ignores_builder.add(4..10);

--- a/src/ignore_markers.rs
+++ b/src/ignore_markers.rs
@@ -10,11 +10,11 @@ impl IgnoreMarkers {
         IgnoreMarkersBuilder::new()
     }
 
-    pub fn contains(&self, index: usize) -> bool {
-        let possible_ignores_end = self
+    pub fn check_marked(&self, index: usize) -> bool {
+        let relevant_range_cap = self
             .ignore_ranges
             .partition_point(|range| range.start <= index);
-        self.ignore_ranges[..possible_ignores_end]
+        self.ignore_ranges[..relevant_range_cap]
             .iter()
             .any(|range| index < range.end)
     }
@@ -47,13 +47,13 @@ mod test {
     use super::*;
 
     #[test]
-    fn ignores() {
-        let mut ignores_builder = IgnoreMarkers::builder();
-        ignores_builder.add(3..10);
-        ignores_builder.add(4..9);
-        ignores_builder.add(4..10);
-        ignores_builder.add(11..13);
-        let ignores = ignores_builder.build();
+    fn ignore_markers() {
+        let mut ignore_markers_builder = IgnoreMarkers::builder();
+        ignore_markers_builder.add(3..10);
+        ignore_markers_builder.add(4..9);
+        ignore_markers_builder.add(4..10);
+        ignore_markers_builder.add(11..13);
+        let ignore_markers = ignore_markers_builder.build();
 
         let tests = [
             (1, false),
@@ -70,12 +70,12 @@ mod test {
             (12, true),
             (13, false),
         ];
-        tests.into_iter().for_each(|(index, expect_contained)| {
+        tests.into_iter().for_each(|(index, expected)| {
             assert_eq!(
-                ignores.contains(index),
-                expect_contained,
-                "index {index}: expected {expect_contained}, got {}",
-                ignores.contains(index)
+                ignore_markers.check_marked(index),
+                expected,
+                "index {index}: expected {expected}, got {}",
+                ignore_markers.check_marked(index)
             );
         });
     }

--- a/src/ignore_markers.rs
+++ b/src/ignore_markers.rs
@@ -18,6 +18,11 @@ impl IgnoreMarkers {
             .iter()
             .any(|range| index < range.end)
     }
+
+    #[cfg(test)]
+    pub fn ignore_ranges(&self) -> &[Range<usize>] {
+        &self.ignore_ranges
+    }
 }
 
 pub struct IgnoreMarkersBuilder {

--- a/src/ignore_markers.rs
+++ b/src/ignore_markers.rs
@@ -37,7 +37,7 @@ impl IgnoreMarkersBuilder {
 
     pub fn build(self) -> IgnoreMarkers {
         let Self { mut ignore_ranges } = self;
-        ignore_ranges.sort_by_key(|range| (range.start, -(range.end as i64)));
+        ignore_ranges.sort_by_key(|range| range.start);
         IgnoreMarkers { ignore_ranges }
     }
 }

--- a/src/ignores.rs
+++ b/src/ignores.rs
@@ -1,0 +1,79 @@
+use std::ops::Range;
+
+pub struct Ignores {
+    ignores: Vec<Range<usize>>,
+}
+
+impl Ignores {
+    pub fn builder() -> IgnoresBuilder {
+        IgnoresBuilder::new()
+    }
+
+    pub fn contains(&self, index: usize) -> bool {
+        let possible_ignores_end = self.ignores.partition_point(|range| range.start <= index);
+        self.ignores[..possible_ignores_end]
+            .iter()
+            .any(|range| index < range.end)
+    }
+}
+
+pub struct IgnoresBuilder {
+    ignores: Vec<Range<usize>>,
+}
+
+impl IgnoresBuilder {
+    pub fn new() -> Self {
+        Self {
+            ignores: Vec::new(),
+        }
+    }
+
+    pub fn add(&mut self, range: Range<usize>) {
+        self.ignores.push(range)
+    }
+
+    pub fn build(self) -> Ignores {
+        let Self { mut ignores } = self;
+        ignores.sort_by_key(|range| (range.start, -(range.end as i64)));
+        Ignores { ignores }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn ignores() {
+        let mut ignores_builder = Ignores::builder();
+        ignores_builder.add(3..10);
+        ignores_builder.add(4..9);
+        ignores_builder.add(4..10);
+        ignores_builder.add(11..13);
+        let ignores = ignores_builder.build();
+
+        let tests = [
+            (1, false),
+            (2, false),
+            (3, true),
+            (4, true),
+            (5, true),
+            (6, true),
+            (7, true),
+            (8, true),
+            (9, true),
+            (10, false),
+            (11, true),
+            (12, true),
+            (13, false),
+        ];
+        tests.into_iter().for_each(|(index, expect_contained)| {
+            assert_eq!(
+                ignores.contains(index),
+                expect_contained,
+                "index {index}: expected {expect_contained}, got {}",
+                ignores.contains(index)
+            );
+        });
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -186,7 +186,7 @@ fn vex(ctx: &Context, store: &VexingStore, max_problems: MaxProblems) -> Result<
             .map(|p| SourcePath::new(&p, &ctx.project_root))
             .map(|p| {
                 let language = associations.get_language(&p)?;
-                SourceFile::new(p, language)
+                Ok(SourceFile::new(p, language))
             })
             .collect::<Result<Vec<_>>>()?
     };
@@ -409,7 +409,7 @@ fn parse(parse_args: ParseCmd) -> Result<()> {
             .unwrap_or_else(Associations::base)
             .get_language(&src_path)?,
     };
-    let src_file = SourceFile::new(src_path, language)?.parse()?;
+    let src_file = SourceFile::new(src_path, language).parse()?;
     println!("{}", src_file.tree.root_node().to_sexp());
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -206,7 +206,7 @@ fn vex(ctx: &Context, store: &VexingStore, max_problems: MaxProblems) -> Result<
         let observe_opts = ObserveOptions {
             action: Action::Vexing(event.kind()),
             query_cache: &query_cache,
-            ignores: None,
+            ignore_markers: None,
         };
         store.observers_for(event.kind()).observe(
             &handler_module,
@@ -245,7 +245,7 @@ fn vex(ctx: &Context, store: &VexingStore, max_problems: MaxProblems) -> Result<
             let observe_opts = ObserveOptions {
                 action: Action::Vexing(event.kind()),
                 query_cache: &query_cache,
-                ignores: None,
+                ignore_markers: None,
             };
             store.observers_for(event.kind()).observe(
                 &handler_module,
@@ -275,7 +275,7 @@ fn vex(ctx: &Context, store: &VexingStore, max_problems: MaxProblems) -> Result<
             continue; // No need to parse, the user will never search this.
         }
         let parsed_file = file.parse()?;
-        let ignores = parsed_file.ignores();
+        let ignore_markers = parsed_file.ignore_markers();
         project_queries
             .iter()
             .chain(file_queries.iter())
@@ -302,7 +302,7 @@ fn vex(ctx: &Context, store: &VexingStore, max_problems: MaxProblems) -> Result<
                         let observe_opts = ObserveOptions {
                             action: Action::Vexing(EventKind::Match),
                             query_cache: &query_cache,
-                            ignores: Some(&ignores),
+                            ignore_markers: Some(&ignore_markers),
                         };
                         on_match.observe(&handler_module, event, observe_opts)?;
                         handler_module

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ mod check_id;
 mod cli;
 mod context;
 mod error;
-mod ignores;
+mod ignore_markers;
 mod irritation;
 mod logger;
 mod plural;
@@ -206,6 +206,7 @@ fn vex(ctx: &Context, store: &VexingStore, max_problems: MaxProblems) -> Result<
         let observe_opts = ObserveOptions {
             action: Action::Vexing(event.kind()),
             query_cache: &query_cache,
+            ignores: None,
         };
         store.observers_for(event.kind()).observe(
             &handler_module,
@@ -244,6 +245,7 @@ fn vex(ctx: &Context, store: &VexingStore, max_problems: MaxProblems) -> Result<
             let observe_opts = ObserveOptions {
                 action: Action::Vexing(event.kind()),
                 query_cache: &query_cache,
+                ignores: None,
             };
             store.observers_for(event.kind()).observe(
                 &handler_module,
@@ -273,6 +275,7 @@ fn vex(ctx: &Context, store: &VexingStore, max_problems: MaxProblems) -> Result<
             continue; // No need to parse, the user will never search this.
         }
         let parsed_file = file.parse()?;
+        let ignores = parsed_file.ignores();
         project_queries
             .iter()
             .chain(file_queries.iter())
@@ -299,6 +302,7 @@ fn vex(ctx: &Context, store: &VexingStore, max_problems: MaxProblems) -> Result<
                         let observe_opts = ObserveOptions {
                             action: Action::Vexing(EventKind::Match),
                             query_cache: &query_cache,
+                            ignores: Some(&ignores),
                         };
                         on_match.observe(&handler_module, event, observe_opts)?;
                         handler_module

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod check_id;
 mod cli;
 mod context;
 mod error;
+mod ignores;
 mod irritation;
 mod logger;
 mod plural;

--- a/src/scriptlets/app_object.rs
+++ b/src/scriptlets/app_object.rs
@@ -130,8 +130,8 @@ impl AppObject {
             let mut irritation_renderer =
                 IrritationRenderer::new(temp_data.vex_path.dupe(), message);
             if let Some(at) = at {
-                if let Some(ignores) = temp_data.ignores {
-                    if ignores.contains(at.0.byte_range().start) {
+                if let Some(ignore_markers) = temp_data.ignore_markers {
+                    if ignore_markers.check_marked(at.0.byte_range().start) {
                         return Ok(NoneType);
                     }
                 }

--- a/src/scriptlets/app_object.rs
+++ b/src/scriptlets/app_object.rs
@@ -126,9 +126,16 @@ impl AppObject {
             }
 
             let ret_data = UnfrozenRetainedData::get_from(eval.module());
-            let vex_path = TempData::get_from(eval).vex_path.dupe();
-            let mut irritation_renderer = IrritationRenderer::new(vex_path.dupe(), message);
+            let temp_data = TempData::get_from(eval);
+            let mut irritation_renderer =
+                IrritationRenderer::new(temp_data.vex_path.dupe(), message);
             if let Some(at) = at {
+                if let Some(ignores) = temp_data.ignores {
+                    if ignores.contains(at.0.byte_range().start) {
+                        return Ok(NoneType);
+                    }
+                }
+
                 irritation_renderer.set_source(at)
             }
             if let Some(show_also) = show_also {

--- a/src/scriptlets/extra_data.rs
+++ b/src/scriptlets/extra_data.rs
@@ -8,7 +8,7 @@ use starlark::{
 use starlark_derive::{starlark_value, NoSerialize, Trace};
 
 use crate::{
-    ignores::Ignores,
+    ignore_markers::IgnoreMarkers,
     scriptlets::{
         action::Action,
         intents::{UnfrozenIntent, UnfrozenIntents},
@@ -100,7 +100,7 @@ pub struct TempData<'v> {
     pub action: Action,
     pub query_cache: &'v QueryCache,
     pub vex_path: PrettyPath,
-    pub ignores: Option<&'v Ignores>,
+    pub ignore_markers: Option<&'v IgnoreMarkers>,
 }
 
 impl<'v> TempData<'v> {

--- a/src/scriptlets/extra_data.rs
+++ b/src/scriptlets/extra_data.rs
@@ -8,6 +8,7 @@ use starlark::{
 use starlark_derive::{starlark_value, NoSerialize, Trace};
 
 use crate::{
+    ignores::Ignores,
     scriptlets::{
         action::Action,
         intents::{UnfrozenIntent, UnfrozenIntents},
@@ -95,14 +96,15 @@ impl<'v> AllocValue<'v> for RetainedData {
 }
 
 #[derive(Debug, ProvidesStaticType)]
-pub struct TempData<'qc> {
+pub struct TempData<'v> {
     pub action: Action,
-    pub query_cache: &'qc QueryCache,
+    pub query_cache: &'v QueryCache,
     pub vex_path: PrettyPath,
+    pub ignores: Option<&'v Ignores>,
 }
 
-impl<'qc> TempData<'qc> {
-    pub fn get_from(eval: &Evaluator<'_, 'qc>) -> &'qc Self {
+impl<'v> TempData<'v> {
+    pub fn get_from(eval: &Evaluator<'_, 'v>) -> &'v Self {
         eval.extra
             .expect("internal error: Evaluator extra not set")
             .downcast_ref()

--- a/src/scriptlets/observers.rs
+++ b/src/scriptlets/observers.rs
@@ -8,7 +8,7 @@ use starlark::{
 use starlark_derive::{starlark_value, NoSerialize, ProvidesStaticType, Trace};
 
 use crate::{
-    ignores::Ignores,
+    ignore_markers::IgnoreMarkers,
     result::Result,
     scriptlets::{
         action::Action, event::EventKind, extra_data::TempData, handler_module::HandlerModule,
@@ -111,7 +111,7 @@ pub trait Observable {
 pub struct ObserveOptions<'v> {
     pub action: Action,
     pub query_cache: &'v QueryCache,
-    pub ignores: Option<&'v Ignores>,
+    pub ignore_markers: Option<&'v IgnoreMarkers>,
 }
 
 impl Observable for Observer {
@@ -125,7 +125,7 @@ impl Observable for Observer {
             action: opts.action,
             query_cache: opts.query_cache,
             vex_path: self.vex_path.dupe(),
-            ignores: opts.ignores,
+            ignore_markers: opts.ignore_markers,
         };
 
         let mut eval = Evaluator::new(handler_module);

--- a/src/scriptlets/observers.rs
+++ b/src/scriptlets/observers.rs
@@ -8,6 +8,7 @@ use starlark::{
 use starlark_derive::{starlark_value, NoSerialize, ProvidesStaticType, Trace};
 
 use crate::{
+    ignores::Ignores,
     result::Result,
     scriptlets::{
         action::Action, event::EventKind, extra_data::TempData, handler_module::HandlerModule,
@@ -107,9 +108,10 @@ pub trait Observable {
 }
 
 #[derive(Clone, Debug, Dupe)]
-pub struct ObserveOptions<'qc> {
+pub struct ObserveOptions<'v> {
     pub action: Action,
-    pub query_cache: &'qc QueryCache,
+    pub query_cache: &'v QueryCache,
+    pub ignores: Option<&'v Ignores>,
 }
 
 impl Observable for Observer {
@@ -123,6 +125,7 @@ impl Observable for Observer {
             action: opts.action,
             query_cache: opts.query_cache,
             vex_path: self.vex_path.dupe(),
+            ignores: opts.ignores,
         };
 
         let mut eval = Evaluator::new(handler_module);

--- a/src/scriptlets/scriptlet.rs
+++ b/src/scriptlets/scriptlet.rs
@@ -106,6 +106,7 @@ impl PreinitingScriptlet {
                     action: Action::Preiniting,
                     vex_path: path.pretty_path.dupe(),
                     query_cache: &QueryCache::new(),
+                    ignores: None,
                 };
                 let mut eval = Evaluator::new(&preinited_module);
                 eval.set_loader(&cache);
@@ -323,6 +324,7 @@ impl InitingScriptlet {
                     action: Action::Initing,
                     query_cache: &QueryCache::new(),
                     vex_path: path.pretty_path.dupe(),
+                    ignores: None,
                 };
                 let mut eval = Evaluator::new(&module);
                 eval.extra = Some(&temp_data);

--- a/src/scriptlets/scriptlet.rs
+++ b/src/scriptlets/scriptlet.rs
@@ -106,7 +106,7 @@ impl PreinitingScriptlet {
                     action: Action::Preiniting,
                     vex_path: path.pretty_path.dupe(),
                     query_cache: &QueryCache::new(),
-                    ignores: None,
+                    ignore_markers: None,
                 };
                 let mut eval = Evaluator::new(&preinited_module);
                 eval.set_loader(&cache);
@@ -324,7 +324,7 @@ impl InitingScriptlet {
                     action: Action::Initing,
                     query_cache: &QueryCache::new(),
                     vex_path: path.pretty_path.dupe(),
-                    ignores: None,
+                    ignore_markers: None,
                 };
                 let mut eval = Evaluator::new(&module);
                 eval.extra = Some(&temp_data);

--- a/src/source_file.rs
+++ b/src/source_file.rs
@@ -19,9 +19,9 @@ pub struct SourceFile {
 }
 
 impl SourceFile {
-    pub fn new(path: SourcePath, language: Option<SupportedLanguage>) -> Result<Self> {
+    pub fn new(path: SourcePath, language: Option<SupportedLanguage>) -> Self {
         let path = path.dupe();
-        Ok(Self { path, language })
+        Self { path, language }
     }
 
     pub fn path(&self) -> &SourcePath {

--- a/src/source_file.rs
+++ b/src/source_file.rs
@@ -3,10 +3,11 @@ use std::fs;
 use allocative::Allocative;
 use dupe::Dupe;
 use log::{info, log_enabled};
-use tree_sitter::{Parser, Tree};
+use tree_sitter::{Parser, QueryCursor, Tree};
 
 use crate::{
     error::{Error, IOAction},
+    ignore_markers::IgnoreMarkers,
     result::Result,
     source_path::SourcePath,
     supported_language::SupportedLanguage,
@@ -86,6 +87,19 @@ impl ParsedSourceFile {
             tree,
             language,
         })
+    }
+
+    pub fn ignore_markers(&self) -> IgnoreMarkers {
+        let mut builder = IgnoreMarkers::builder();
+
+        let ignore_query = self.language.ignore_query();
+        QueryCursor::new()
+            .matches(ignore_query, self.tree.root_node(), self.content.as_bytes())
+            .flat_map(|qmatch| qmatch.captures)
+            .map(|qcap| qcap.node.byte_range())
+            .for_each(|ignore_range| builder.add(ignore_range));
+
+        builder.build()
     }
 }
 

--- a/src/supported_language.rs
+++ b/src/supported_language.rs
@@ -154,7 +154,7 @@ mod test {
                     };
                 }
             "#})
-            .ignores(&[18..31, 36..87, 92..108, 113..164]);
+            .ignores_ranges(&[18..31, 36..87, 92..108, 113..164]);
         Test::language(SupportedLanguage::Cpp)
             .with_source(indoc! {r#"
                 void main() {
@@ -172,7 +172,7 @@ mod test {
                     };
                 }
             "#})
-            .ignores(&[18..31, 36..91, 96..112, 117..174]);
+            .ignores_ranges(&[18..31, 36..91, 96..112, 117..174]);
         Test::language(SupportedLanguage::Go)
             .with_source(indoc! {r#"
                 package main
@@ -186,7 +186,7 @@ mod test {
                     }
                 }
             "#})
-            .ignores(&[32..45, 50..100]);
+            .ignores_ranges(&[32..45, 50..100]);
         Test::language(SupportedLanguage::Python)
             .with_source(indoc! {r#"
                 def main():
@@ -197,7 +197,7 @@ mod test {
                         3,
                     ]
             "#})
-            .ignores(&[16..28, 33..77]);
+            .ignores_ranges(&[16..28, 33..77]);
         Test::language(SupportedLanguage::Rust)
             .with_source(indoc! {r#"
                 fn main() {
@@ -209,7 +209,7 @@ mod test {
                     ];
                 }
             "#})
-            .ignores(&[16..29, 34..83]);
+            .ignores_ranges(&[16..29, 34..83]);
 
         // Test structs
         #[must_use]
@@ -231,7 +231,7 @@ mod test {
                 self
             }
 
-            fn ignores(self, ranges: &[Range<usize>]) {
+            fn ignores_ranges(self, ranges: &[Range<usize>]) {
                 self.setup();
 
                 let source_file = ParsedSourceFile::new_with_content(

--- a/src/supported_language.rs
+++ b/src/supported_language.rs
@@ -4,10 +4,11 @@ use allocative::Allocative;
 use clap::Subcommand;
 use dupe::Dupe;
 use enum_map::{Enum, EnumMap};
+use indoc::indoc;
 use lazy_static::lazy_static;
 use serde::{Deserialize as Deserialise, Serialize as Serialise};
 use strum::{EnumIter, IntoEnumIterator};
-use tree_sitter::Language;
+use tree_sitter::{Language, Query};
 
 use crate::{error::Error, result::Result};
 
@@ -63,6 +64,35 @@ impl SupportedLanguage {
             Self::Rust => tree_sitter_rust::language(),
         })
     }
+
+    pub fn ignore_query(&self) -> &Query {
+        lazy_static! {
+            static ref IGNORE_QUERIES: EnumMap<SupportedLanguage, OnceLock<Query>> =
+                SupportedLanguage::iter()
+                    .zip(iter::repeat_with(OnceLock::new))
+                    .collect();
+        }
+
+        IGNORE_QUERIES[*self].get_or_init(|| {
+            let raw = match self {
+                Self::C | Self::Cpp | Self::Go | Self::Python => indoc! {r#"
+                    (
+                        (comment) @ignore_tag (#match-any? @ignore_tag "^// vex:ignore" "^/\* vex:ignore")
+                        .
+                        (_) @ignore
+                    )
+                "#},
+                Self::Rust => indoc! {r#"
+                    (
+                        (line_comment) @ignore_tag (#match? @ignore_tag "^// vex:ignore")
+                        .
+                        (_) @ignore
+                    )
+                "#},
+            };
+            Query::new(self.ts_language(), raw).expect("internal error: ignore query invalid")
+        })
+    }
 }
 
 impl FromStr for SupportedLanguage {
@@ -88,7 +118,12 @@ impl Display for SupportedLanguage {
 
 #[cfg(test)]
 mod test {
+    use std::ops::Range;
+
     use strum::IntoEnumIterator;
+    use tree_sitter::QueryCursor;
+
+    use crate::{source_file::ParsedSourceFile, source_path::SourcePath};
 
     use super::*;
 
@@ -98,5 +133,130 @@ mod test {
             assert_eq!(lang, lang.name().parse()?);
         }
         Ok(())
+    }
+
+    #[test]
+    fn ignore_extraction() {
+        Test::language(SupportedLanguage::C)
+            .with_source(indoc! {r#"
+                void main() {
+                    // vex:ignore
+                    int x[] = {
+                        1,
+                        2,
+                        3,
+                    };
+                    /* vex:ignore */
+                    int y[] = {
+                        1,
+                        2,
+                        3,
+                    };
+                }
+            "#})
+            .ignores(&[18..31, 36..87, 92..108, 113..164]);
+        Test::language(SupportedLanguage::Cpp)
+            .with_source(indoc! {r#"
+                void main() {
+                    // vex:ignore
+                    vector<int> x {
+                        1,
+                        2,
+                        3,
+                    };
+                    /* vex:ignore */
+                    vector<int> y = {
+                        1,
+                        2,
+                        3,
+                    };
+                }
+            "#})
+            .ignores(&[18..31, 36..91, 96..112, 117..174]);
+        Test::language(SupportedLanguage::Go)
+            .with_source(indoc! {r#"
+                package main
+
+                func main() {
+                    // vex:ignore
+                    x := []int{
+                        1,
+                        2,
+                        3,
+                    }
+                }
+            "#})
+            .ignores(&[32..45, 50..100]);
+        Test::language(SupportedLanguage::Python)
+            .with_source(indoc! {r#"
+                def main():
+                    # vex:ignore
+                    x = [
+                        1,
+                        2,
+                        3,
+                    ]
+            "#})
+            .ignores(&[16..28, 33..77]);
+        Test::language(SupportedLanguage::Rust)
+            .with_source(indoc! {r#"
+                fn main() {
+                    // vex:ignore
+                    let x = [
+                        1,
+                        2,
+                        3,
+                    ];
+                }
+            "#})
+            .ignores(&[16..29, 34..83]);
+
+        // Test structs
+        #[must_use]
+        struct Test {
+            language: SupportedLanguage,
+            source: Option<&'static str>,
+        }
+
+        impl Test {
+            fn language(language: SupportedLanguage) -> Self {
+                Self {
+                    language,
+                    source: None,
+                }
+            }
+
+            fn with_source(mut self, source: &'static str) -> Self {
+                self.source = Some(source);
+                self
+            }
+
+            fn ignores(self, ranges: &[Range<usize>]) {
+                self.setup();
+
+                let source_file = ParsedSourceFile::new_with_content(
+                    SourcePath::new_in("test.file".into(), "".into()),
+                    self.source.unwrap(),
+                    self.language,
+                )
+                .unwrap();
+
+                let query = self.language.ignore_query();
+                let ignore_ranges: Vec<_> = QueryCursor::new()
+                    .matches(
+                        query,
+                        source_file.tree.root_node(),
+                        source_file.content.as_bytes(),
+                    )
+                    .flat_map(|qmatch| qmatch.captures)
+                    .map(|qcap| qcap.node.byte_range())
+                    .collect();
+                assert_eq!(ranges, ignore_ranges);
+            }
+
+            fn setup(&self) {
+                eprintln!("running {} test...", self.language);
+            }
+        }
     }
 }

--- a/src/supported_language.rs
+++ b/src/supported_language.rs
@@ -136,7 +136,7 @@ mod test {
     }
 
     #[test]
-    fn ignore_extraction() {
+    fn ignore_queries() {
         Test::language(SupportedLanguage::C)
             .with_source(indoc! {r#"
                 void main() {
@@ -241,10 +241,10 @@ mod test {
                 )
                 .unwrap();
 
-                let query = self.language.ignore_query();
+                let ignore_query = self.language.ignore_query();
                 let ignore_ranges: Vec<_> = QueryCursor::new()
                     .matches(
-                        query,
+                        ignore_query,
                         source_file.tree.root_node(),
                         source_file.content.as_bytes(),
                     )


### PR DESCRIPTION
This PR adds support for marking sections of source code as 'ignored' by vex. For example, in the following snippet—
```rust
// vex:ignore
let x = {
    ...
};
```
Any warnings which would be annotated as being in the let-expression (including the contained block) are ignored.
