### PR TITLE
PrettyPath API cleaning

### DIFF
--- a/src/source_path.rs
+++ b/src/source_path.rs
@@ -94,7 +94,7 @@ impl PrettyPath {
         return self.sanitised_path.as_ref();
     }
 
-    pub fn component_count(&self) -> usize {
+    pub fn num_components(&self) -> usize {
         self.path.components().count()
     }
 
@@ -115,8 +115,8 @@ impl PrettyPath {
         }
 
         #[allow(clippy::needless_lifetimes)]
-        fn component_count(this: &PrettyPath) -> starlark::Result<i32> {
-            Ok(this.component_count() as i32)
+        fn num_components(this: &PrettyPath) -> starlark::Result<i32> {
+            Ok(this.num_components() as i32)
         }
     }
 }
@@ -187,7 +187,7 @@ impl<'v> StarlarkValue<'v> for PrettyPath {
         let Some(mut index) = index.unpack_i32() else {
             return ValueError::unsupported_with(self, "[]", index)?;
         };
-        let n = self.component_count() as i32;
+        let n = self.num_components() as i32;
         if index >= n || index < -n {
             return Err(ValueError::IndexOutOfBound(index).into());
         }
@@ -212,7 +212,7 @@ impl<'v> StarlarkValue<'v> for PrettyPath {
         stride: Option<Value<'v>>,
         heap: &'v Heap,
     ) -> starlark::Result<Value<'v>> {
-        let n = self.component_count() as i32;
+        let n = self.num_components() as i32;
         let start = start.and_then(Value::unpack_i32);
         let stop = stop.and_then(Value::unpack_i32);
         let stride = stride.and_then(Value::unpack_i32).unwrap_or(1);
@@ -376,16 +376,16 @@ mod test {
     }
 
     #[test]
-    fn component_count() {
+    fn num_components() {
         PathTest::new("absolute-unix")
             .path("/")
-            .run("check['eq'](path.component_count(), 1)");
+            .run("check['eq'](path.num_components(), 1)");
         PathTest::new("absolute-windows")
             .path("A:")
-            .run("check['eq'](path.component_count(), 1)");
+            .run("check['eq'](path.num_components(), 1)");
         PathTest::new("normal-unix")
             .path("src/main.rs")
-            .run("check['eq'](path.component_count(), 2)");
+            .run("check['eq'](path.num_components(), 2)");
     }
 
     #[test]

--- a/src/source_path.rs
+++ b/src/source_path.rs
@@ -168,6 +168,10 @@ impl<'v> StarlarkValue<'v> for PrettyPath {
             .unwrap_or_default())
     }
 
+    fn length(&self) -> starlark::Result<i32> {
+        Ok(self.as_str().len() as i32)
+    }
+
     fn is_in(&self, other: Value<'v>) -> starlark::Result<bool> {
         let Some(str) = other.unpack_str() else {
             return Err(ValueError::IncorrectParameterTypeWithExpected(
@@ -386,6 +390,19 @@ mod test {
         PathTest::new("normal-unix")
             .path("src/main.rs")
             .run("check['eq'](path.num_components(), 2)");
+    }
+
+    #[test]
+    fn len() {
+        PathTest::new("absolute-unix")
+            .path("/")
+            .run("check['eq'](len(path), 1)");
+        PathTest::new("absolute-windows")
+            .path("A:")
+            .run("check['eq'](len(path), 2)");
+        PathTest::new("normal-unix")
+            .path("src/main.rs")
+            .run("check['eq'](len(path), 11)");
     }
 
     #[test]


### PR DESCRIPTION
Let `p` be a pretty path representing `foo/bar`. Currently, `len(p) == 2`, representing the number of components. This is quite unexpected given the string-like nature of the data.
This PR makes `len(p) == len(str(p))` and adds a new method—`p.num_components() == 2`

This PR also makes path-slicing return a path. Slicing is done by component
