### PR TITLE
Default to expanded structure output

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -244,9 +244,9 @@ pub struct ParseCmd {
     #[arg(value_name = "file")]
     pub path: Utf8PathBuf,
 
-    /// Pretty-print structure and include location info
+    /// Remove location info, line-breaks and indentation
     #[arg(long)]
-    pub expanded: bool,
+    pub compact: bool,
 
     /// Override language detection
     #[arg(long = "as", value_name = "language")]

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -33,10 +33,10 @@ pub fn parse(cmd: ParseCmd) -> Result<()> {
 
     let capacity_estimate = 20 * src_file.tree.root_node().descendant_count();
     let mut buf = String::with_capacity(capacity_estimate);
-    let format = if cmd.expanded {
-        WhitespaceStyle::Expanded
-    } else {
+    let format = if cmd.compact {
         WhitespaceStyle::Compact
+    } else {
+        WhitespaceStyle::Expanded
     };
     NodePrinter::new(&mut buf, format).write(&src_file)?;
     println!("{buf}");


### PR DESCRIPTION
Use in practice indicates that the expanded pretty-printed node representation is a more useful default for the `parse` command
