### PR TITLE
Consider all `warn!` and `error!` calls before outputting 'success'

### DIFF
--- a/src/logger.rs
+++ b/src/logger.rs
@@ -5,8 +5,8 @@ use log::{kv::Key, Level, Log, Metadata, Record};
 
 use crate::{result::Result, verbosity::Verbosity};
 
-static NUM_ERRS: Mutex<u32> = Mutex::new(0);
-static NUM_WARNINGS: Mutex<u32> = Mutex::new(0);
+pub static NUM_ERRS: Mutex<u32> = Mutex::new(0);
+pub static NUM_WARNINGS: Mutex<u32> = Mutex::new(0);
 
 pub fn init(level: Verbosity) -> Result<()> {
     let level = level.into();

--- a/src/main.rs
+++ b/src/main.rs
@@ -127,11 +127,13 @@ fn check(cmd_args: CheckCmd) -> Result<()> {
             Plural::new(num_files_scanned, "file", "files"),
         );
     }
-    if !irritations.is_empty() {
-        warn!(
-            "found {}",
-            Plural::new(irritations.len(), "problem", "problems"),
-        );
+    let num_problems = irritations.len()
+        + *logger::NUM_ERRS.lock().expect("failed to lock NUM_ERRS") as usize
+        + *logger::NUM_WARNINGS
+            .lock()
+            .expect("failed to lock NUM_WARNINGS") as usize;
+    if num_problems != 0 {
+        warn!("found {}", Plural::new(num_problems, "problem", "problems"),);
     } else {
         println!(
             "{}: no problems found",


### PR DESCRIPTION
This PR fixes a bug where success can be reported after warnings and errors have occurred:
```
warn: oh no!
success: no problems found
```
This PR causes the total warnings and errors to be included in addition to the total irritations
