### PR TITLE
Make starlark paths only represent valid paths

### DIFF
--- a/src/source_path.rs
+++ b/src/source_path.rs
@@ -386,12 +386,15 @@ mod test {
 
     #[test]
     fn components() {
-        PathTest::new("absolute-unix")
-            .path("/")
-            .run("check['eq'](path.components(), ['/'])");
-        PathTest::new("absolute-windows")
-            .path("A:")
-            .run("check['eq'](path.components(), ['A:'])");
+        if !cfg!(target_os = "windows") {
+            PathTest::new("absolute-unix")
+                .path("/")
+                .run("check['eq'](path.components(), ['/'])");
+        } else {
+            PathTest::new("absolute-windows")
+                .path("A:")
+                .run("check['eq'](path.components(), ['A:'])");
+        }
         PathTest::new("normal-unix")
             .path("src/main.rs")
             .run("check['eq'](path.components(), ['src', 'main.rs'])");

--- a/src/source_path.rs
+++ b/src/source_path.rs
@@ -487,12 +487,8 @@ mod test {
 
                 errs = []
                 def eq(start, stop, stride, a, b):
-                    # print('%r, %r, %r...' % (start, stop, stride))
-                    # print('checking: %r == %r' % (a, b))
-
                     if type(a) != 'string':
                         fail('expected list, got %s' % type(a))
-
                     if a != b:
                         errs.append('[%r:%r:%r]: %r %r' % (start, stop, stride, a, b))
 
@@ -504,29 +500,29 @@ mod test {
                     b = slice(expected, start, stop, stride)
                     eq(start, stop, stride, a, b)
 
-                def slice(recv, start, stop, stride):
+                def slice(obj, start, stop, stride):
                     if start != None:
                         if stop != None:
                             if stride != None:
-                                return recv[start:stop:stride]
+                                return obj[start:stop:stride]
                             else:
-                                return recv[start:stop:]
+                                return obj[start:stop:]
                         else:
                             if stride != None:
-                                return recv[start::stride]
+                                return obj[start::stride]
                             else:
-                                return recv[start::]
+                                return obj[start::]
                     else:
                         if stop != None:
                             if stride != None:
-                                return recv[:stop:stride]
+                                return obj[:stop:stride]
                             else:
-                                return recv[:stop:]
+                                return obj[:stop:]
                         else:
                             if stride != None:
-                                return recv[::stride]
+                                return obj[::stride]
                             else:
-                                return recv[::]
+                                return obj[::]
 
                 for (start, stop, stride) in tests:
                     test(start, stop, stride)


### PR DESCRIPTION
This PR removes the confusing component-slice behaviour and puts in into a separate method.

Specifically, let `p` be a path with value `foo/bar/baz.rs`. Under the new behaviour we have that—
```python
p[*:*:*] == str(p)[*:*:*]
type(p[*:*:*]) == 'str'
p.components() == ['foo', 'bar', 'baz.rs']
```

This changes gives us the invariant that all Starlark paths correspond to paths valid at the start of execution.
