### PR TITLE
Rename `vex parse` to `vex dump`

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ def on_open_project(event):
         ''',
 ```
 Note that in this [Scheme][scheme] query, we have labelled certain nodes for later use: `@left_operand`, `@right-operand` and `@bin_expr`.
-(For a given file, to see the syntax tree these queries are performed against, run `vex parse path/to/file`.)
+(For a given file, to see the syntax tree these queries are performed against, run `vex dump path/to/file`.)
 
 To react to a syntax-tree node being found which matches the above query, add a callback function (we’ll call this `on_match`)—
 ```python

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -49,7 +49,7 @@ pub enum Command {
     Init(InitCmd),
 
     /// Print the syntax tree of the given file
-    Parse(ParseCmd),
+    Dump(DumpCmd),
 }
 
 #[cfg(test)]
@@ -61,9 +61,9 @@ impl Command {
         }
     }
 
-    pub fn into_parse_cmd(self) -> Option<ParseCmd> {
+    pub fn into_dump_cmd(self) -> Option<DumpCmd> {
         match self {
-            Self::Parse(p) => Some(p),
+            Self::Dump(p) => Some(p),
             _ => None,
         }
     }
@@ -243,7 +243,7 @@ const OVERRIDES: [(&[u8], &[u8]); 2] = [
 ];
 
 #[derive(Debug, Default, PartialEq, Eq, Parser)]
-pub struct ParseCmd {
+pub struct DumpCmd {
     /// File to parse
     #[arg(value_name = "file")]
     pub path: Utf8PathBuf,
@@ -414,35 +414,35 @@ mod test {
         }
     }
 
-    mod parse {
+    mod dump {
         use super::*;
 
         #[test]
         fn requires_path() {
-            Args::try_parse_from(["vex", "parse"]).unwrap_err();
+            Args::try_parse_from(["vex", "dump"]).unwrap_err();
         }
 
         #[test]
         fn relative_path() {
             const PATH: &str = "./src/main.rs";
-            let args = Args::try_parse_from(["vex", "parse", PATH]).unwrap();
-            let parse_cmd = args.into_command().into_parse_cmd().unwrap();
-            assert_eq!(parse_cmd.path, PATH);
+            let args = Args::try_parse_from(["vex", "dump", PATH]).unwrap();
+            let dump_cmd = args.into_command().into_dump_cmd().unwrap();
+            assert_eq!(dump_cmd.path, PATH);
         }
 
         #[test]
         fn absolute_path() {
             const PATH: &str = "/src/main.rs";
-            let args = Args::try_parse_from(["vex", "parse", PATH]).unwrap();
-            let parse_cmd = args.into_command().into_parse_cmd().unwrap();
-            assert_eq!(parse_cmd.path, PATH);
+            let args = Args::try_parse_from(["vex", "dump", PATH]).unwrap();
+            let dump_cmd = args.into_command().into_dump_cmd().unwrap();
+            assert_eq!(dump_cmd.path, PATH);
         }
 
         #[test]
         fn language() {
-            let args = Args::try_parse_from(["vex", "parse", "asdf.foo", "--as", "rust"]).unwrap();
-            let parse_cmd = args.into_command().into_parse_cmd().unwrap();
-            assert_eq!(SupportedLanguage::Rust, parse_cmd.language.unwrap());
+            let args = Args::try_parse_from(["vex", "dump", "asdf.foo", "--as", "rust"]).unwrap();
+            let dump_cmd = args.into_command().into_dump_cmd().unwrap();
+            assert_eq!(SupportedLanguage::Rust, dump_cmd.language.unwrap());
         }
     }
 

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -4,7 +4,7 @@ use camino::{Utf8Path, Utf8PathBuf};
 
 use crate::{
     associations::Associations,
-    cli::ParseCmd,
+    cli::DumpCmd,
     context::Context,
     error::{Error, IOAction},
     result::Result,
@@ -13,7 +13,7 @@ use crate::{
     source_path::{PrettyPath, SourcePath},
 };
 
-pub fn parse(cmd: ParseCmd) -> Result<()> {
+pub fn dump(cmd: DumpCmd) -> Result<()> {
     let cwd = Utf8PathBuf::try_from(env::current_dir().map_err(|e| Error::IO {
         path: PrettyPath::new(Utf8Path::new(&cmd.path)),
         action: IOAction::Read,
@@ -86,7 +86,7 @@ mod test {
     }
 
     #[test]
-    fn parse_valid_file() {
+    fn dump_valid_file() {
         let test_file = TestFile::new(
             "path/to/file.rs",
             indoc! {r#"
@@ -96,17 +96,17 @@ mod test {
             "#},
         );
 
-        let args = Args::try_parse_from(["vex", "parse", test_file.path.as_str()]).unwrap();
-        let cmd = args.command.into_parse_cmd().unwrap();
-        parse(cmd).unwrap();
+        let args = Args::try_parse_from(["vex", "dump", test_file.path.as_str()]).unwrap();
+        let cmd = args.command.into_dump_cmd().unwrap();
+        dump(cmd).unwrap();
     }
 
     #[test]
-    fn parse_nonexistent_file() {
+    fn dump_nonexistent_file() {
         let file_path = "/i/do/not/exist.rs";
-        let args = Args::try_parse_from(["vex", "parse", file_path]).unwrap();
-        let cmd = args.command.into_parse_cmd().unwrap();
-        let err = parse(cmd).unwrap_err();
+        let args = Args::try_parse_from(["vex", "dump", file_path]).unwrap();
+        let cmd = args.command.into_dump_cmd().unwrap();
+        let err = dump(cmd).unwrap_err();
         if cfg!(target_os = "windows") {
             assert_eq!(
                 err.to_string(),
@@ -121,16 +121,16 @@ mod test {
     }
 
     #[test]
-    fn parse_invalid_file() {
+    fn dump_invalid_file() {
         let test_file = TestFile::new(
             "src/file.rs",
             indoc! {r#"
                 i am not valid a valid rust file!
             "#},
         );
-        let args = Args::try_parse_from(["vex", "parse", test_file.path.as_str()]).unwrap();
-        let cmd = args.command.into_parse_cmd().unwrap();
-        let err = parse(cmd).unwrap_err();
+        let args = Args::try_parse_from(["vex", "dump", test_file.path.as_str()]).unwrap();
+        let cmd = args.command.into_dump_cmd().unwrap();
+        let err = dump(cmd).unwrap_err();
         assert_eq!(
             err.to_string(),
             format!(
@@ -143,9 +143,9 @@ mod test {
     #[test]
     fn no_extension() {
         let test_file = TestFile::new("no-extension", "");
-        let args = Args::try_parse_from(["vex", "parse", test_file.path.as_str()]).unwrap();
-        let cmd = args.command.into_parse_cmd().unwrap();
-        let err = parse(cmd).unwrap_err();
+        let args = Args::try_parse_from(["vex", "dump", test_file.path.as_str()]).unwrap();
+        let cmd = args.command.into_dump_cmd().unwrap();
+        let err = dump(cmd).unwrap_err();
 
         // Assertion relaxed due to strange Github Actions Windows and Macos runner path handling.
         let expected = format!(
@@ -161,9 +161,9 @@ mod test {
     #[test]
     fn unknown_extension() {
         let test_file = TestFile::new("file.unknown-extension", "");
-        let args = Args::try_parse_from(["vex", "parse", test_file.path.as_str()]).unwrap();
-        let cmd = args.command.into_parse_cmd().unwrap();
-        let err = parse(cmd).unwrap_err();
+        let args = Args::try_parse_from(["vex", "dump", test_file.path.as_str()]).unwrap();
+        let cmd = args.command.into_dump_cmd().unwrap();
+        let err = dump(cmd).unwrap_err();
         assert_eq!(
             err.to_string(),
             format!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,11 +7,11 @@ extern crate pretty_assertions;
 mod associations;
 mod cli;
 mod context;
+mod dump;
 mod error;
 mod ignore_markers;
 mod irritation;
 mod logger;
-mod parse;
 mod plural;
 mod query;
 mod result;
@@ -86,7 +86,7 @@ fn run() -> Result<ExitCode> {
         Command::Check(cmd_args) => check(cmd_args),
         Command::List(list_args) => list(list_args),
         Command::Init(init_args) => init(init_args),
-        Command::Parse(parse_args) => parse::parse(parse_args),
+        Command::Dump(dump_args) => dump::dump(dump_args),
     }?;
 
     Ok(logger::exit_code())


### PR DESCRIPTION
User feedback indicates that `dump` is a more intuitive name than `parse` for the subcommand to display parsed file structure
