### PR TITLE
Add `profile` feature for `vex check`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /vexes/
 test_project/
 *.snap.new
+*.svg

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,12 +13,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "addr2line"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
+ "getrandom",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -138,6 +154,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
 name = "ascii-canvas"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,6 +173,21 @@ name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+
+[[package]]
+name = "backtrace"
+version = "0.3.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "beef"
@@ -190,6 +227,12 @@ name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+
+[[package]]
+name = "bytemuck"
+version = "1.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b236fc92302c97ed75b38da1f4917b5cdda4984745740f153a5d3059e48d725e"
 
 [[package]]
 name = "byteorder"
@@ -290,6 +333,7 @@ dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
+ "unicode-width",
  "windows-sys 0.52.0",
 ]
 
@@ -320,6 +364,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
+name = "cpp_demangle"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8227005286ec39567949b33df9896bcadfa6051bccca2488129f108ca23119"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,6 +386,15 @@ checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "uuid",
 ]
 
 [[package]]
@@ -538,6 +600,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "findshlibs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -577,6 +651,12 @@ dependencies = [
  "libc",
  "wasi",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "glob"
@@ -639,10 +719,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "763a5a8f45087d6bcea4222e7b72c291a054edf80e4ef6efd2a4979878c7bea3"
+dependencies = [
+ "console",
+ "instant",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+]
+
+[[package]]
 name = "indoc"
 version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
+
+[[package]]
+name = "inferno"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "321f0f839cd44a4686e9504b0a62b4d69a50b62072144c71c68f5873c167b8d9"
+dependencies = [
+ "ahash",
+ "indexmap",
+ "is-terminal",
+ "itoa",
+ "log",
+ "num-format",
+ "once_cell",
+ "quick-xml",
+ "rgb",
+ "str_stack",
+]
 
 [[package]]
 name = "insta"
@@ -655,6 +766,15 @@ dependencies = [
  "linked-hash-map",
  "serde",
  "similar",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -840,12 +960,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "memmap2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
+dependencies = [
+ "adler",
 ]
 
 [[package]]
@@ -885,6 +1023,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-format"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
+dependencies = [
+ "arrayvec",
+ "itoa",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -900,6 +1048,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
+name = "object"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "081b846d1d56ddfc18fdf1a922e4f6e07a11768ea1b92dec44e42b72712ccfce"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -972,6 +1135,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
+
+[[package]]
+name = "pprof"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef5c97c51bd34c7e742402e216abdeb44d415fbe6ae41d56b114723e953711cb"
+dependencies = [
+ "backtrace",
+ "cfg-if",
+ "findshlibs",
+ "inferno",
+ "libc",
+ "log",
+ "nix",
+ "once_cell",
+ "parking_lot",
+ "smallvec",
+ "symbolic-demangle",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
 name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -994,6 +1184,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1069,6 +1268,21 @@ name = "regex-syntax"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+
+[[package]]
+name = "rgb"
+version = "0.8.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7439be6844e40133eda024efd85bf07f59d0dd2f59b10c00dd6cfb92cc5c741"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc_version"
@@ -1251,6 +1465,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "starlark"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1352,6 +1572,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
 
 [[package]]
+name = "str_stack"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb"
+
+[[package]]
 name = "string_cache"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1406,6 +1632,29 @@ checksum = "d6398cde53adc3c4557306a96ce67b302968513830a77a95b2b17305d9719a89"
 dependencies = [
  "is-terminal",
  "is_ci",
+]
+
+[[package]]
+name = "symbolic-common"
+version = "12.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71297dc3e250f7dbdf8adb99e235da783d690f5819fdeb4cce39d9cfb0aca9f1"
+dependencies = [
+ "debugid",
+ "memmap2",
+ "stable_deref_trait",
+ "uuid",
+]
+
+[[package]]
+name = "symbolic-demangle"
+version = "12.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "424fa2c9bf2c862891b9cfd354a752751a6730fd838a4691e7f6c2c7957b9daf"
+dependencies = [
+ "cpp_demangle",
+ "rustc-demangle",
+ "symbolic-common",
 ]
 
 [[package]]
@@ -1658,6 +1907,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de17fd2f7da591098415cff336e12965a28061ddace43b59cb3c430179c9439"
+
+[[package]]
 name = "value-bag"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1684,6 +1939,7 @@ dependencies = [
  "dupe",
  "enum-map",
  "glob",
+ "indicatif",
  "indoc",
  "insta",
  "joinery",
@@ -1692,6 +1948,7 @@ dependencies = [
  "num-traits",
  "owo-colors",
  "paste",
+ "pprof",
  "pretty_assertions",
  "regex",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+profile = ["dep:pprof", "dep:indicatif"]
+
 [dependencies]
 allocative = "0.3.1"
 annotate-snippets = "0.10.0"
@@ -24,6 +27,7 @@ log = { version = "0.4.20", features = ["std", "kv_unstable"] }
 num-traits = "0.2.17"
 owo-colors = { version = "4.0.0", features = ["supports-colors"] }
 paste = "1.0.15"
+pprof = { version = "0.13.0", features = ["flamegraph"], optional = true }
 regex = "1.10.3"
 serde = { version = "1.0.193", features = ["derive", "rc"] }
 smallvec = "1.13.2"
@@ -41,6 +45,7 @@ tree-sitter-python = "0.21"
 tree-sitter-rust = "0.21"
 tree-sitter-cpp = "0.21"
 uniquote = "4.0.0"
+indicatif = { version = "0.17.8", optional = true }
 
 [dev-dependencies]
 insta = { version = "1.36.1", features = ["yaml"] }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -124,7 +124,7 @@ pub struct CheckCmd {
 //     }
 // }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum MaxProblems {
     Unlimited,
     Limited(u32),

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,7 +166,7 @@ fn check(cmd_args: CheckCmd) -> Result<()> {
     }
 
     #[cfg(feature = "profile")]
-    profile::profile("vex-check-complete", || {
+    profile::profile("vex-check", || {
         let store = {
             let preinit_opts = PreinitOptions {
                 lenient: cmd_args.lenient,

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,9 @@ use source_file::SourceFile;
 use strum::IntoEnumIterator;
 use tree_sitter::QueryCursor;
 
+#[cfg(feature = "profile")]
+use indicatif::{ProgressIterator, ProgressStyle};
+
 use crate::{
     cli::{Args, CheckCmd, Command},
     context::{Context, EXAMPLE_VEX_FILE},
@@ -161,6 +164,45 @@ fn check(cmd_args: CheckCmd) -> Result<()> {
             "{}: no problems found",
             "success".if_supports_color(Stream::Stdout, |text| text.style(*SUCCESS_STYLE))
         );
+    }
+
+    #[cfg(feature = "profile")]
+    {
+        const REPS_ENV_VAR: &str = "VEX_PROFILE_REPS";
+        println!(
+            "repeating the operations many times, adjust how many by setting `${REPS_ENV_VAR}`"
+        );
+        let reps: u32 = env::var(REPS_ENV_VAR)
+            .as_deref()
+            .unwrap_or("100")
+            .parse()
+            .unwrap();
+
+        let guard = pprof::ProfilerGuardBuilder::default()
+            .frequency(1000)
+            .build()
+            .unwrap();
+
+        let progress_style = ProgressStyle::default_bar()
+            .template(
+                "[{elapsed_precise}] {wide_bar:.green/blue} {human_pos:>7}/{human_len:7} {msg}",
+            )
+            .unwrap()
+            .progress_chars("=>-");
+        (0..reps)
+            .progress_with_style(progress_style)
+            .try_for_each(|_| {
+                std::hint::black_box(vex(&ctx, &store, cmd_args.max_problems))?;
+                Ok::<_, Error>(())
+            })?;
+
+        if let Ok(report) = guard.report().build() {
+            const OUTPUT_FILE_NAME: &str = "flamegraph.svg";
+            report
+                .flamegraph(std::fs::File::create(OUTPUT_FILE_NAME).unwrap())
+                .unwrap();
+            println!("flamegraph written to {OUTPUT_FILE_NAME}");
+        }
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,9 +166,15 @@ fn check(cmd_args: CheckCmd) -> Result<()> {
     }
 
     #[cfg(feature = "profile")]
-    profile::profile(|| {
-        std::hint::black_box(vex(&ctx, &store, cmd_args.max_problems))?;
-        Ok::<_, Error>(())
+    profile::profile("vex-check-complete", || {
+        let store = {
+            let preinit_opts = PreinitOptions {
+                lenient: cmd_args.lenient,
+            };
+            PreinitingStore::new(&ctx)?.preinit(preinit_opts)?.init()?
+        };
+        vex(&ctx, &store, cmd_args.max_problems)?;
+        Result::Ok(())
     })
     .unwrap();
 

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -1,0 +1,39 @@
+use std::env;
+
+use indicatif::{ProgressIterator, ProgressStyle};
+
+pub fn profile<E>(f: impl Fn() -> Result<(), E>) -> Result<(), E> {
+    const REPS_ENV_VAR: &str = "VEX_PROFILE_REPS";
+    println!("repeating the operations many times, adjust how many by setting `${REPS_ENV_VAR}`");
+    let reps: u32 = env::var(REPS_ENV_VAR)
+        .as_deref()
+        .unwrap_or("100")
+        .parse()
+        .unwrap();
+
+    let guard = pprof::ProfilerGuardBuilder::default()
+        .frequency(1000)
+        .build()
+        .expect("internal error: failed to build profile guard");
+
+    let progress_style = ProgressStyle::default_bar()
+        .template("[{elapsed_precise}] {wide_bar:.green/red} {human_pos:>7}/{human_len:7} {msg}")
+        .expect("internal error: failed to parse progress template")
+        .progress_chars("=>-");
+    (0..reps)
+        .progress_with_style(progress_style)
+        .try_for_each(|_| f())?;
+
+    if let Ok(report) = guard.report().build() {
+        const OUTPUT_FILE_NAME: &str = "flamegraph.svg";
+        report
+            .flamegraph(
+                std::fs::File::create(OUTPUT_FILE_NAME)
+                    .expect("internal error: failed to create file"),
+            )
+            .expect("internal error: failed to write flamegraph");
+        println!("flamegraph written to {OUTPUT_FILE_NAME}");
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
This PR adds rudamentary profiling to the `check` subcommand. A flamegraph is output in the current directory showing the result of running the vexing portion of `check` many times. The default number of times is 1000, but this may be tuned at runtime with the `VEX_PROFILE_REPS` environment variable.
