### PR TITLE
Make `str(node)` match tree-sitter behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ def on_match(event):
     left_operand = event.captures['left_operand']
     right_operand = event.captures['right_operand']
     bin_expr = event.captures['bin_expr']
-    if int(left_operand.text()) >= int(right_operand.text()) / 1000:
+    if int(str(left_operand)) >= int(str(right_operand)) / 1000:
         vex.warn(
             'large operands should come later',
             at=(left_operand, 'number too large'),

--- a/src/context.rs
+++ b/src/context.rs
@@ -79,13 +79,13 @@ impl Context {
                 # underscores.
 
                 lit = event.captures['lit']
-                lit_text = lit.text()
+                lit_str = str(lit)
 
-                if lit_text.startswith('0x') or lit_text.startswith('0b'):
+                if lit_str.startswith('0x') or lit_str.startswith('0b'):
                     return
-                if len(lit_text) <= 6:
+                if len(lit_str) <= 6:
                     return
-                if '_' in lit_text:
+                if '_' in lit_str:
                     return
 
                 vex.warn(

--- a/src/scriptlets/node.rs
+++ b/src/scriptlets/node.rs
@@ -23,7 +23,7 @@ use starlark_derive::{starlark_attrs, starlark_module, starlark_value, StarlarkA
 use strum::EnumIs;
 use tree_sitter::{Node as TSNode, Point, TreeCursor};
 
-use crate::{error::Error, result::Result, source_file::ParsedSourceFile};
+use crate::{result::Result, source_file::ParsedSourceFile};
 
 #[derive(new, Clone, Debug, PartialEq, Eq, ProvidesStaticType, NoSerialize, Allocative)]
 pub struct Node<'v> {
@@ -87,6 +87,12 @@ impl<'v> Node<'v> {
             .map(|ts_node| Self::new(ts_node, self.source_file))
     }
 
+    pub fn to_complete_sexp(&self) -> Result<String> {
+        let mut expr = String::new();
+        NodePrinter::new(&mut expr, WhitespaceStyle::Compact).write_node(self, None)?;
+        Ok(expr)
+    }
+
     #[starlark_module]
     fn methods(builder: &mut MethodsBuilder) {
         fn is_extra<'v>(this: Node<'v>) -> starlark::Result<bool> {
@@ -129,10 +135,8 @@ impl<'v> Node<'v> {
             Ok(this.child_count())
         }
 
-        fn text<'v>(this: Node<'v>) -> starlark::Result<&'v str> {
-            this.utf8_text(this.source_file.content.as_bytes())
-                .map_err(Error::Utf8)
-                .map_err(starlark::Error::new_other)
+        fn expr<'v>(this: Node<'v>) -> starlark::Result<String> {
+            this.to_complete_sexp().map_err(starlark::Error::new_other)
         }
     }
 }
@@ -240,13 +244,9 @@ impl<'v> AllocValue<'v> for Node<'v> {
 impl Display for Node<'_> {
     #[allow(clippy::print_in_format_impl)]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut buf = String::new();
-        if let Err(err) =
-            NodePrinter::new(&mut buf, WhitespaceStyle::Compact).write(self.source_file)
-        {
-            eprintln!("node formatter failed: {err}");
-        }
-        f.write_str(&buf)
+        self.utf8_text(self.source_file.content.as_bytes())
+            .map_err(|_| std::fmt::Error)?
+            .fmt(f)
     }
 }
 
@@ -394,10 +394,10 @@ impl<'w, W: Write> NodePrinter<'w, W> {
 
     pub fn write(&mut self, src_file: &ParsedSourceFile) -> Result<()> {
         let root = Node::new(src_file.tree.root_node(), src_file);
-        self.write_node(root, None)
+        self.write_node(&root, None)
     }
 
-    fn write_node(&mut self, node: Node<'_>, field_name: Option<&'static str>) -> Result<()> {
+    fn write_node(&mut self, node: &Node<'_>, field_name: Option<&'static str>) -> Result<()> {
         let expandable_separator = self.whitespace_style.expandable_separator();
 
         self.write_indent()?;
@@ -417,7 +417,7 @@ impl<'w, W: Write> NodePrinter<'w, W> {
             .try_for_each(|(i, child)| {
                 write!(self.out, "{expandable_separator}")?;
                 let field_name = node.field_name_for_child(i as u32);
-                self.write_node(child, field_name)
+                self.write_node(&child, field_name)
             })?;
         self.curr_indent -= 1;
 
@@ -426,7 +426,7 @@ impl<'w, W: Write> NodePrinter<'w, W> {
             self.write_indent()?;
         }
         write!(self.out, ")")?;
-        self.write_location(&Location::of(&node))?;
+        self.write_location(&Location::of(node))?;
         Ok(())
     }
 
@@ -596,10 +596,47 @@ mod test {
                             bin_expr = event.captures['bin_expr']
 
                             check['type'](bin_expr, 'Node')
-                            check['true'](str(bin_expr).startswith('(')) # Looks like an s-expression
-                            check['true'](str(bin_expr).endswith(')'))   # Looks like an s-expression
                             check['eq'](str(bin_expr), repr(bin_expr))
-                            check['in']('("+")', str(bin_expr))
+                    "#,
+                    check_path = VexTest::CHECK_STARLARK_PATH,
+                },
+            )
+            .with_source_file(
+                "src/main.rs",
+                indoc! {r#"
+                    fn main() {
+                        let x = 1 + (2 + 3);
+                        println!("{x}");
+                    }
+                "#},
+            )
+            .assert_irritation_free();
+    }
+
+    #[test]
+    fn expr() {
+        VexTest::new("expr")
+            .with_scriptlet(
+                "vexes/test.star",
+                formatdoc! {r#"
+                        load('{check_path}', 'check')
+
+                        def init():
+                            vex.observe('open_project', on_open_project)
+
+                        def on_open_project(event):
+                            vex.search(
+                                'rust',
+                                '(binary_expression left: (integer_literal) @l_int) @bin_expr',
+                                on_match,
+                            )
+
+                        def on_match(event):
+                            bin_expr = event.captures['bin_expr']
+                            bin_expr_expr = bin_expr.expr()
+                            check['true'](bin_expr_expr.startswith('(binary_expression')) # Looks like an s-expression
+                            check['true'](bin_expr_expr.endswith(')'))   # Looks like an s-expression
+                            check['in']('("+")', bin_expr_expr)
                     "#,
                     check_path = VexTest::CHECK_STARLARK_PATH,
                 },
@@ -648,7 +685,7 @@ mod test {
                                 'parents',
                                 'previous_sibling',
                                 'previous_siblings',
-                                'text',
+                                'expr',
                             ]
                             check['attrs'](event.captures['bin_expr'], expected_attrs)
                     "#,
@@ -957,48 +994,6 @@ mod test {
                     fn main() {
                         let x = 1 +
                             (2 + 3);
-                        println!("{x}");
-                    }
-                "#},
-            )
-            .assert_irritation_free();
-    }
-
-    #[test]
-    fn text() {
-        VexTest::new("text")
-            .with_scriptlet(
-                "vexes/test.star",
-                formatdoc! {r#"
-                        load('{check_path}', 'check')
-
-                        def init():
-                            vex.observe('open_project', on_open_project)
-
-                        def on_open_project(event):
-                            vex.search(
-                                'rust',
-                                '''
-                                    (binary_expression
-                                        left: (integer_literal) @l_int
-                                        right: (parenthesized_expression)
-                                    ) @bin_expr
-                                ''',
-                                on_match,
-                            )
-
-                        def on_match(event):
-                            bin_expr = event.captures['bin_expr']
-                            check['eq'](bin_expr.text(), '1 + (2 + 3)')
-                    "#,
-                    check_path = VexTest::CHECK_STARLARK_PATH,
-                },
-            )
-            .with_source_file(
-                "src/main.rs",
-                indoc! {r#"
-                    fn main() {
-                        let x = 1 + (2 + 3);
                         println!("{x}");
                     }
                 "#},

--- a/src/scriptlets/query_captures.rs
+++ b/src/scriptlets/query_captures.rs
@@ -711,19 +711,30 @@ mod test {
             .collect();
         matches.sort_by_cached_key(|cap| cap.to_string());
         assert_eq!(2, matches.len());
-        assert_eq!(matches[0].get_type(), "Node");
-        assert!(matches[0].to_string().contains("let_declaration"));
-        assert_eq!(matches[1].get_type(), "list");
-        assert!(matches[1]
+        assert_eq!(matches[0].get_type(), "list");
+        assert!(matches[0]
             .at(heap.alloc(0), &heap)
             .unwrap()
-            .to_string()
+            .request_value::<&Node>()
+            .unwrap()
+            .to_complete_sexp()
+            .unwrap()
             .contains("line_comment"));
-        assert!(matches[1]
+        assert!(matches[0]
             .at(heap.alloc(1), &heap)
             .unwrap()
-            .to_string()
+            .request_value::<&Node>()
+            .unwrap()
+            .to_complete_sexp()
+            .unwrap()
             .contains("line_comment"));
+        assert_eq!(matches[1].get_type(), "Node");
+        assert!(matches[1]
+            .request_value::<&Node>()
+            .unwrap()
+            .to_complete_sexp()
+            .unwrap()
+            .contains("let_declaration"));
     }
 
     #[test]
@@ -777,7 +788,10 @@ mod test {
             assert!(matches[0]
                 .at(heap.alloc(i), &heap)
                 .unwrap()
-                .to_string()
+                .request_value::<&Node>()
+                .unwrap()
+                .to_complete_sexp()
+                .unwrap()
                 .contains(node_kind));
         })
     }


### PR DESCRIPTION
Currently, `str(node)` outputs the S-expression form of a node and `node.text()` outputs the text it covers. This is sub-optimal as vexes are more likely to require the text of a node than its S-expression form.

This PR shifts the existing functionality into better API, one which more closely matches the tree-sitter match behaviour where the text is more important then the node's structure during queries. The new API is as follows.

Assume that `node` is a Rust binary expression node which covers the text `1 + 2`. The following now hold:
```python
str(node) == '1 + 2'
node.expr() == '(binary_expression left: (integer_literal) ("+") right: (integer_literal))'
```
