### PR TITLE
Move top-level manifest keys under `[vex]`

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -130,7 +130,8 @@ impl Context {
     }
 
     pub fn vex_dir(&self) -> Utf8PathBuf {
-        self.project_root.join(self.manifest.queries_dir.as_str())
+        self.project_root
+            .join(self.manifest.metadata.queries_dir.as_str())
     }
 }
 
@@ -145,22 +146,17 @@ impl Deref for Context {
 #[derive(Debug, Default, Deserialise, Serialise, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 pub struct Manifest {
+    #[serde(rename = "vex")]
+    pub metadata: Metadata,
+
     #[serde(flatten)]
     pub language_options: LanguageData,
-
-    #[serde(default)]
-    pub queries_dir: QueriesDir,
-
-    #[serde(default, rename = "ignore")]
-    pub ignores: IgnoreData,
-
-    #[serde(default, rename = "allow")]
-    pub allows: Vec<RawFilePattern<String>>,
 }
 
 impl Manifest {
     const FILE_NAME: &'static str = "vex.toml";
     const DEFAULT_CONTENT: &'static str = indoc! {r#"
+        [vex]
         ignore = [ "vex.toml", "vexes/", ".git/", ".gitignore", "/target/" ]
 
         # If this is a C++ project where header files have file-extension .h, uncomment the
@@ -248,6 +244,18 @@ impl Manifest {
 
         Ok((project_root, raw_data))
     }
+}
+
+#[derive(Debug, Default, Deserialise, Serialise, PartialEq)]
+pub struct Metadata {
+    #[serde(default)]
+    pub queries_dir: QueriesDir,
+
+    #[serde(default, rename = "ignore")]
+    pub ignores: IgnoreData,
+
+    #[serde(default, rename = "allow")]
+    pub allows: Vec<RawFilePattern<String>>,
 }
 
 #[derive(Debug, Deserialise, Serialise, PartialEq)]
@@ -344,9 +352,10 @@ mod test {
     fn default_manifest_valid() {
         let init_manifest: Manifest =
             toml_edit::de::from_str(Manifest::DEFAULT_CONTENT).expect("default manifest invalid");
-        assert!(init_manifest.allows.is_empty());
+        assert!(init_manifest.metadata.allows.is_empty());
         assert_eq!(
             init_manifest
+                .metadata
                 .ignores
                 .iter()
                 .map(RawFilePattern::to_string)
@@ -445,7 +454,8 @@ mod test {
         let tempdir = tempfile::tempdir().unwrap();
         let tempdir_path = Utf8PathBuf::try_from(tempdir.path().to_owned())?;
 
-        File::create(tempdir_path.join("vex.toml")).unwrap();
+        let mut manifest = File::create(tempdir_path.join("vex.toml")).unwrap();
+        manifest.write_all("[vex]".as_bytes()).unwrap();
 
         let re = Regex::new("^cannot find vexes directory at .*").unwrap();
         let ctx = Context::acquire_in(&tempdir_path).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -183,6 +183,7 @@ fn vex(ctx: &Context, store: &VexingStore, max_problems: MaxProblems) -> Result<
     let files = {
         let mut paths = Vec::new();
         let ignores = ctx
+            .metadata
             .ignores
             .clone()
             .into_inner()
@@ -190,6 +191,7 @@ fn vex(ctx: &Context, store: &VexingStore, max_problems: MaxProblems) -> Result<
             .map(|ignore| ignore.compile())
             .collect::<Result<Vec<_>>>()?;
         let allows = ctx
+            .metadata
             .allows
             .clone()
             .into_iter()
@@ -428,7 +430,7 @@ fn init(init_args: InitCmd) -> Result<()> {
         cause,
     })?)?;
     Context::init(cwd, init_args.force)?;
-    let queries_dir = Context::acquire()?.manifest.queries_dir;
+    let queries_dir = Context::acquire()?.manifest.metadata.queries_dir;
     printdoc!(
         "
             {}: vex initialised

--- a/src/vextest.rs
+++ b/src/vextest.rs
@@ -126,7 +126,7 @@ impl<'s> VexTest<'s> {
         let root_path = Utf8PathBuf::try_from(root_dir.path().to_path_buf()).unwrap();
 
         if !self.bare {
-            let manifest_content = self.manifest_content.as_deref().unwrap_or_default();
+            let manifest_content = self.manifest_content.as_deref().unwrap_or("[vex]");
             File::create(root_path.join("vex.toml"))
                 .unwrap()
                 .write_all(manifest_content.as_bytes())


### PR DESCRIPTION
This PR brands Vex manifest content
