### PR TITLE
Add status information to print handler

### DIFF
--- a/src/scriptlets/action.rs
+++ b/src/scriptlets/action.rs
@@ -11,6 +11,14 @@ pub enum Action {
 }
 
 impl Action {
+    pub fn name(&self) -> &'static str {
+        match self {
+            Self::Preiniting => "pre_init",
+            Self::Initing => "init",
+            Self::Vexing(e) => e.name(),
+        }
+    }
+
     pub fn pretty_name(&self) -> &'static str {
         match self {
             Self::Preiniting => "preiniting",

--- a/src/scriptlets/observers.rs
+++ b/src/scriptlets/observers.rs
@@ -127,10 +127,10 @@ impl Observable for Observer {
             vex_id: self.vex_id.dupe(),
             ignore_markers: opts.ignore_markers,
         };
-
+        let print_handler = PrintHandler::new(opts.action.name());
         let mut eval = Evaluator::new(handler_module);
         eval.extra = Some(&temp_data);
-        eval.set_print_handler(&PrintHandler);
+        eval.set_print_handler(&print_handler);
 
         let func = self.callback.dupe().to_value(); // TODO(kcza): check thread safety! Can this unfrozen
                                                     // function mutate upvalues if it is a closure?

--- a/src/scriptlets/print_handler.rs
+++ b/src/scriptlets/print_handler.rs
@@ -1,8 +1,16 @@
-pub struct PrintHandler;
+pub struct PrintHandler<'prefix> {
+    prefix: &'prefix str,
+}
 
-impl starlark::PrintHandler for PrintHandler {
+impl<'prefix> PrintHandler<'prefix> {
+    pub fn new(prefix: &'prefix str) -> Self {
+        Self { prefix }
+    }
+}
+
+impl starlark::PrintHandler for PrintHandler<'_> {
     fn println(&self, text: &str) -> anyhow::Result<()> {
-        println!("{text}");
+        println!("[{}]: {text}", self.prefix);
         Ok(())
     }
 }

--- a/src/scriptlets/scriptlet.rs
+++ b/src/scriptlets/scriptlet.rs
@@ -112,9 +112,10 @@ impl PreinitingScriptlet {
                     query_cache: &QueryCache::new(),
                     ignore_markers: None,
                 };
+                let print_handler = PrintHandler::new(path.pretty_path.as_str());
                 let mut eval = Evaluator::new(&preinited_module);
                 eval.set_loader(&cache);
-                eval.set_print_handler(&PrintHandler);
+                eval.set_print_handler(&print_handler);
                 eval.extra = Some(&temp_data);
                 eval.eval_module(ast, &Self::globals(*lenient))?;
             };
@@ -325,9 +326,10 @@ impl InitingScriptlet {
                     vex_id: vex_id.dupe(),
                     ignore_markers: None,
                 };
+                let print_handler = PrintHandler::new(path.pretty_path.as_str());
                 let mut eval = Evaluator::new(&module);
                 eval.extra = Some(&temp_data);
-                eval.set_print_handler(&PrintHandler);
+                eval.set_print_handler(&print_handler);
                 eval.eval_function(init.value(), &[], &[])?;
             }
             module.into_module().freeze()?

--- a/src/source_path.rs
+++ b/src/source_path.rs
@@ -307,7 +307,7 @@ mod test {
 
             let path = PrettyPath::new(Utf8Path::new(self.path.expect("path not set")));
             let module = Module::new();
-            module.set("path", module.heap().alloc(path));
+            module.set("path", module.heap().alloc(path.dupe()));
 
             let code = formatdoc! {r#"
                     load('{check_path}', 'check')
@@ -321,8 +321,9 @@ mod test {
                 ..Dialect::Standard
             };
             let ast = AstModule::parse("vexes/test.star", code.to_string(), &dialect).unwrap();
+            let print_handler = PrintHandler::new(path.as_str());
             let mut eval = Evaluator::new(&module);
-            eval.set_print_handler(&PrintHandler);
+            eval.set_print_handler(&print_handler);
             eval.set_loader(&TestModuleCache);
             eval.eval_module(ast, &Self::globals()).map(|_| ())
         }


### PR DESCRIPTION
This PR prefixes `print` output with the name of the event which triggered it
