### PR TITLE
Forbid relative paths

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -231,6 +231,9 @@ pub enum InvalidLoadReason {
     #[display(fmt = "load path cannot contain both `./` and `../`")]
     MixedPathOperators,
 
+    #[display(fmt = "load path cannot be relative")]
+    Relative,
+
     #[display(fmt = "load path invalid, see docs")] // TODO(kcza): link to spec once public.
     NonSpecific,
 }

--- a/src/scriptlets/scriptlet.rs
+++ b/src/scriptlets/scriptlet.rs
@@ -179,6 +179,10 @@ impl LoadStatementModule<'_> {
             return Err(invalid_load(InvalidLoadReason::Absolute));
         }
 
+        if self.0.starts_with("./") || self.0.starts_with("../") {
+            return Err(invalid_load(InvalidLoadReason::Relative));
+        }
+
         let extension = self_as_path.extension();
         if !matches!(extension, Some("star")) {
             if self.0.len() == ".star".len() {
@@ -738,30 +742,32 @@ mod test {
             .path("abcdefghijklmnopqrstuvwxyz_0123456789.star")
             .ok();
         LoadTest::new("nested").path("aaa/bbb/ccc.star").ok();
-        LoadTest::new("relative-toplevel").path("./aaa.star").ok();
-        LoadTest::new("relative-nested")
-            .path("./aaa/bbb/ccc.star")
-            .ok();
-        LoadTest::new("parent-toplevel").path("../aaa.star").ok();
-        LoadTest::new("parent-nested")
-            .path("../../../aaa/bbb/ccc.star")
-            .ok();
+        // TODO(kcza): reinstate these.
+        // LoadTest::new("relative-toplevel").path("./aaa.star").ok();
+        // LoadTest::new("relative-nested")
+        //     .path("./aaa/bbb/ccc.star")
+        //     .ok();
+        // LoadTest::new("parent-toplevel").path("../aaa.star").ok();
+        // LoadTest::new("parent-nested")
+        //     .path("../../../aaa/bbb/ccc.star")
+        //     .ok();
 
         LoadTest::new("dash")
             .path("---.star")
             .causes("load path can only contain a-z, 0-9, `_`, `.` and `/`, found `-`");
-        LoadTest::new("backslashes")
-            .path(r".\\.\\aaa.star")
-            .causes(r"load path can only contain a-z, 0-9, `_`, `.` and `/`, found `\`");
-        LoadTest::new("extra-starting-current-dir")
-            .path("././aaa.star")
-            .causes("load path cannot contain multiple `./`");
-        LoadTest::new("current-dir-in-parent-dir")
-            .path(".././aaa.star")
-            .causes("load path cannot contain both `./` and `../`");
-        LoadTest::new("parent-op-in-current-dir")
-            .path("./../aaa.star")
-            .causes("load path cannot contain both `./` and `../`");
+        // TODO(kcza): reinstate these.
+        // LoadTest::new("backslashes")
+        //     .path(r".\\.\\aaa.star")
+        //     .causes(r"load path can only contain a-z, 0-9, `_`, `.` and `/`, found `\`");
+        // LoadTest::new("extra-starting-current-dir")
+        //     .path("././aaa.star")
+        //     .causes("load path cannot contain multiple `./`");
+        // LoadTest::new("current-dir-in-parent-dir")
+        //     .path(".././aaa.star")
+        //     .causes("load path cannot contain both `./` and `../`");
+        // LoadTest::new("parent-op-in-current-dir")
+        //     .path("./../aaa.star")
+        //     .causes("load path cannot contain both `./` and `../`");
         LoadTest::new("midway-current-dir")
             .path("aaa/./bbb.star")
             .causes("load path can only have path operators at the start");


### PR DESCRIPTION
This PR adds placeholder behaviour to prevent the use of relative loads until they are implemented in the near future.
