### PR TITLE
Remove short version flag

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -9,7 +9,13 @@ use clap::{
 use crate::{error::Error, supported_language::SupportedLanguage};
 
 #[derive(Debug, Parser)]
-#[command(author, version, about, disable_help_flag = true)]
+#[command(
+    author,
+    version,
+    about,
+    disable_help_flag = true,
+    disable_version_flag = true
+)]
 pub struct Args {
     #[command(subcommand)]
     pub command: Command,
@@ -21,6 +27,10 @@ pub struct Args {
     /// Print help information, use `--help` for more detail
     #[arg(short, long, action=ArgAction::Help, global=true)]
     help: Option<bool>,
+
+    /// Print version
+    #[arg(long, action=ArgAction::Version)]
+    version: Option<bool>,
 }
 
 impl Args {


### PR DESCRIPTION
By default, `clap` adds a short `-V` version flag. This PR removes this flag as it is out of line with the capitalisation of other flags, is too visually-similar to the `-v` verbosity flag and is unlikely to be used frequently anyway, hence `--version` alone is sufficient
