### PR TITLE
Remove auto-generation of vex IDs

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -85,7 +85,6 @@ pub struct ListCmd {
 
 #[derive(Clone, Debug, PartialEq, Eq, ValueEnum)]
 pub enum ToList {
-    Checks,
     Languages,
 }
 
@@ -362,18 +361,6 @@ mod test {
                     .into_command(),
                 Command::List(ListCmd {
                     what: ToList::Languages
-                }),
-            );
-        }
-
-        #[test]
-        fn vexes() {
-            assert_eq!(
-                Args::try_parse_from(["vex", "list", "checks"])
-                    .unwrap()
-                    .into_command(),
-                Command::List(ListCmd {
-                    what: ToList::Checks
                 }),
             );
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -105,6 +105,9 @@ pub enum Error {
     #[error(transparent)]
     Query(#[from] tree_sitter::QueryError),
 
+    #[error("ignoring '*' makes other ignore ids redundant")]
+    RedundantIgnoreIDs,
+
     #[error(transparent)]
     SetLogger(#[from] log::SetLoggerError),
 
@@ -168,12 +171,6 @@ impl From<starlark::Error> for Error {
 
 #[derive(Debug, Display)]
 pub enum InvalidIDReason {
-    #[display(fmt = "cannot contain '::'")]
-    ContainsDoubleColon { index: usize },
-
-    #[display(fmt = "cannot contain '--'")]
-    ContainsDoubleDash { index: usize },
-
     #[display(fmt = "can only contain a-z, 0-9, ':' and '-'")]
     IllegalChar,
 
@@ -182,6 +179,9 @@ pub enum InvalidIDReason {
 
     #[display(fmt = "cannot end with '{_0}'")]
     IllegalEndChar(char),
+
+    #[display(fmt = "cannot contain '{found}'")]
+    UglySubstring { found: String, index: usize },
 
     #[display(fmt = "too few characters ({len} < {min_len})")]
     TooShort { len: usize, min_len: usize },

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,7 +7,7 @@ use strum::IntoEnumIterator;
 
 use crate::{
     query::Query,
-    scriptlets::{action::Action, event::EventKind, LoadStatementModule, Location},
+    scriptlets::{action::Action, event::EventKind, LoadStatementModule},
     source_path::PrettyPath,
     supported_language::SupportedLanguage,
 };
@@ -82,12 +82,6 @@ pub enum Error {
 
     #[error("cannot find vexes directory at {0}")]
     NoVexesDir(Utf8PathBuf),
-
-    #[error("{file}:{location}: no vex ids specified")]
-    NoVexIds {
-        file: PrettyPath,
-        location: Location,
-    },
 
     #[error("{0} is not a check path")]
     NotACheckPath(PrettyPath),

--- a/src/error.rs
+++ b/src/error.rs
@@ -106,7 +106,7 @@ pub enum Error {
     Query(#[from] tree_sitter::QueryError),
 
     #[error("ignoring '*' makes other ignore ids redundant")]
-    RedundantIgnoreIDs,
+    RedundantIgnore,
 
     #[error(transparent)]
     SetLogger(#[from] log::SetLoggerError),

--- a/src/ignore_markers.rs
+++ b/src/ignore_markers.rs
@@ -1,9 +1,8 @@
 use std::ops::Range;
 
-use log::{log_enabled, warn};
 use smallvec::SmallVec;
 
-use crate::{scriptlets::Location, source_path::PrettyPath, vex::id::VexId};
+use crate::{error::Error, result::RecoverableResult, vex::id::VexId};
 
 #[derive(Debug)]
 pub struct IgnoreMarkers {
@@ -16,7 +15,7 @@ impl IgnoreMarkers {
         IgnoreMarkersBuilder::new()
     }
 
-    pub fn marked(&self, byte_index: usize, vex_id: VexId) -> bool {
+    pub fn is_ignored(&self, byte_index: usize, vex_id: &VexId) -> bool {
         if self.markers.is_empty() {
             return false;
         }
@@ -123,35 +122,44 @@ impl VexIdFilter {
     // This function creates a new `VexIdFilter` from a comma-separated list of stringified
     // pretty vex ids. If any vex ids are unknown, the first unknown one will be returned as an
     // error.
-    pub fn new(raw: &str, opts: VexIdFilterOpts<'_>) -> Self {
-        if raw == "*" {
-            return Self::All;
+    pub fn try_from_iter<'a>(
+        mut raw_ids: impl Iterator<Item = &'a str>,
+    ) -> RecoverableResult<Self> {
+        let (min, max) = raw_ids.size_hint();
+        let capacity = max.unwrap_or(min);
+
+        let mut ids = SmallVec::with_capacity(capacity);
+        for raw_id in &mut raw_ids {
+            if raw_id == "*" {
+                if !ids.is_empty() || raw_ids.next().is_some() {
+                    return RecoverableResult::Recovered(Self::All, Error::RedundantIgnoreIDs);
+                }
+                return RecoverableResult::Ok(Self::All);
+            }
+            let id = match VexId::try_from(raw_id.to_string()) {
+                Ok(id) => id,
+                Err(err) => {
+                    return RecoverableResult::Recovered(Self::Specific(SmallVec::new()), err)
+                }
+            };
+            ids.push(id)
         }
-        Self::Specific(
-            raw.split(',')
-                .flat_map(|raw_id| {
-                    let id = VexId::retrieve_str(raw_id);
-                    if id.is_none() && log_enabled!(log::Level::Warn) {
-                        warn!("{}:{}: unknown vex '{raw_id}'", opts.path, opts.location)
-                    }
-                    id
-                })
-                .collect(),
-        )
+        RecoverableResult::Ok(Self::Specific(ids))
     }
 
-    fn covers(&self, vex_id: VexId) -> bool {
+    fn covers(&self, vex_id: &VexId) -> bool {
         match self {
             Self::All => true,
-            Self::Specific(ids) => ids.contains(&vex_id),
+            Self::Specific(ids) => ids.contains(vex_id),
         }
     }
-}
 
-#[derive(Debug)]
-pub struct VexIdFilterOpts<'path> {
-    pub path: &'path PrettyPath,
-    pub location: Location,
+    pub fn is_empty(&self) -> bool {
+        match self {
+            Self::All => false,
+            Self::Specific(ids) => ids.is_empty(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -162,18 +170,15 @@ struct MarkerEnd {
 
 #[cfg(test)]
 mod test {
-    use dupe::Dupe;
     use smallvec::smallvec;
-
-    use crate::source_path::PrettyPath;
 
     use super::*;
 
     #[test]
     fn ignore_ranges() {
-        let vex_id = VexId::new(PrettyPath::new("foo/bar.star".into()));
+        let vex_id = VexId::try_from("foo-bar".to_string()).unwrap();
         let ignore_markers = {
-            let filter = VexIdFilter::Specific(smallvec![vex_id.dupe()]);
+            let filter = VexIdFilter::Specific(smallvec![vex_id.clone()]);
             let mut builder = IgnoreMarkers::builder();
             builder.add(3..10, filter.clone());
             builder.add(4..9, filter.clone());
@@ -199,10 +204,10 @@ mod test {
         ];
         tests.into_iter().for_each(|(index, expected)| {
             assert_eq!(
-                ignore_markers.marked(index, vex_id),
+                ignore_markers.is_ignored(index, &vex_id),
                 expected,
                 "index {index}: expected {expected}, got {}",
-                ignore_markers.marked(index, vex_id)
+                ignore_markers.is_ignored(index, &vex_id)
             );
         });
     }

--- a/src/ignore_markers.rs
+++ b/src/ignore_markers.rs
@@ -132,7 +132,7 @@ impl VexIdFilter {
         for raw_id in &mut raw_ids {
             if raw_id == "*" {
                 if !ids.is_empty() || raw_ids.next().is_some() {
-                    return RecoverableResult::Recovered(Self::All, Error::RedundantIgnoreIDs);
+                    return RecoverableResult::Recovered(Self::All, Error::RedundantIgnore);
                 }
                 return RecoverableResult::Ok(Self::All);
             }

--- a/src/ignore_markers.rs
+++ b/src/ignore_markers.rs
@@ -112,7 +112,7 @@ impl IgnoreMarker {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum VexIdFilter {
     All,
     Specific(SmallVec<[VexId; 2]>),
@@ -136,16 +136,13 @@ impl VexIdFilter {
                 star_found = true;
                 continue;
             }
-            let id = match VexId::try_from(raw_id.to_string()) {
-                Ok(id) => id,
-                Err(err) => {
-                    return RecoverableResult::Recovered(Self::Specific(SmallVec::new()), vec![err])
-                }
+            match VexId::try_from(raw_id.to_string()) {
+                Ok(id) => ids.push(id),
+                Err(err) => errs.push(err),
             };
-            ids.push(id)
         }
 
-        if star_found && ids.len() != 1 {
+        if star_found && !ids.is_empty() {
             errs.push(Error::RedundantIgnore)
         }
 

--- a/src/ignore_markers.rs
+++ b/src/ignore_markers.rs
@@ -132,14 +132,14 @@ impl VexIdFilter {
         for raw_id in &mut raw_ids {
             if raw_id == "*" {
                 if !ids.is_empty() || raw_ids.next().is_some() {
-                    return RecoverableResult::Recovered(Self::All, Error::RedundantIgnore);
+                    return RecoverableResult::Recovered(Self::All, vec![Error::RedundantIgnore]);
                 }
                 return RecoverableResult::Ok(Self::All);
             }
             let id = match VexId::try_from(raw_id.to_string()) {
                 Ok(id) => id,
                 Err(err) => {
-                    return RecoverableResult::Recovered(Self::Specific(SmallVec::new()), err)
+                    return RecoverableResult::Recovered(Self::Specific(SmallVec::new()), vec![err])
                 }
             };
             ids.push(id)

--- a/src/irritation.rs
+++ b/src/irritation.rs
@@ -9,14 +9,14 @@ use crate::{
     logger,
     scriptlets::{main_annotation::MainAnnotation, Node},
     source_path::PrettyPath,
-    vex::id::PrettyVexId,
+    vex::id::VexId,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Allocative, Serialize)]
 #[non_exhaustive]
 pub struct Irritation {
     code_source: Option<IrritationSource>,
-    pretty_vex_id: PrettyVexId,
+    vex_id: VexId,
     other_code_sources: Vec<IrritationSource>,
     info_present: bool,
     pub(crate) rendered: String,
@@ -68,7 +68,7 @@ impl Display for Irritation {
 }
 
 pub struct IrritationRenderer<'v> {
-    pretty_vex_id: PrettyVexId,
+    vex_id: VexId,
     message: &'v str,
     source: Option<MainAnnotation<'v>>,
     show_also: Vec<(Node<'v>, &'v str)>,
@@ -76,9 +76,9 @@ pub struct IrritationRenderer<'v> {
 }
 
 impl<'v> IrritationRenderer<'v> {
-    pub fn new(pretty_vex_id: PrettyVexId, message: &'v str) -> Self {
+    pub fn new(vex_id: VexId, message: &'v str) -> Self {
         Self {
-            pretty_vex_id,
+            vex_id,
             message,
             source: None,
             show_also: Vec::with_capacity(0),
@@ -100,18 +100,17 @@ impl<'v> IrritationRenderer<'v> {
 
     pub fn render(self) -> Irritation {
         let Self {
-            pretty_vex_id,
+            vex_id,
             source,
             message,
             show_also,
             info,
         } = self;
 
-        let id = pretty_vex_id.as_str().replace('_', "-"); // TODO(kcza): remove once redundant.
         let file_name = source.as_ref().map(|source| source.pretty_path().as_str());
         let snippet = Snippet {
             title: Some(Annotation {
-                id: Some(&id),
+                id: Some(vex_id.as_ref()),
                 label: Some(message),
                 annotation_type: AnnotationType::Warning,
             }),
@@ -191,7 +190,7 @@ impl<'v> IrritationRenderer<'v> {
         let info_present = info.is_some();
         let rendered = logger::render_snippet(snippet);
         Irritation {
-            pretty_vex_id,
+            vex_id,
             code_source,
             other_code_sources,
             info_present,

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,14 +112,6 @@ fn print_banner() {
 
 fn list(list_args: ListCmd) -> Result<()> {
     match list_args.what {
-        ToList::Checks => {
-            let ctx = Context::acquire()?;
-            let store = PreinitingStore::new(&ctx)?.preinit(PreinitOptions::default())?;
-            store
-                .vexes()
-                .map(|vex| &vex.vex_id)
-                .for_each(|id| println!("{}", id));
-        }
         ToList::Languages => SupportedLanguage::iter().for_each(|lang| println!("{}", lang)),
     }
     Ok(())

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,3 +1,11 @@
 use crate::error::Error;
 
 pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug)]
+#[must_use]
+pub enum RecoverableResult<T> {
+    Ok(T),
+    Recovered(T, Error),
+    Err(Error),
+}

--- a/src/result.rs
+++ b/src/result.rs
@@ -6,6 +6,6 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[must_use]
 pub enum RecoverableResult<T> {
     Ok(T),
-    Recovered(T, Error),
+    Recovered(T, Vec<Error>),
     Err(Error),
 }

--- a/src/scriptlets/extra_data.rs
+++ b/src/scriptlets/extra_data.rs
@@ -15,7 +15,6 @@ use crate::{
         query_cache::QueryCache,
         Intents,
     },
-    vex::id::VexId,
 };
 
 #[derive(Debug, Display, ProvidesStaticType, NoSerialize, Allocative, Trace)]
@@ -99,7 +98,6 @@ impl<'v> AllocValue<'v> for RetainedData {
 pub struct TempData<'v> {
     pub action: Action,
     pub query_cache: &'v QueryCache,
-    pub vex_id: VexId,
     pub ignore_markers: Option<&'v IgnoreMarkers>,
 }
 

--- a/src/scriptlets/observers.rs
+++ b/src/scriptlets/observers.rs
@@ -14,7 +14,6 @@ use crate::{
         action::Action, event::EventKind, extra_data::TempData, handler_module::HandlerModule,
         print_handler::PrintHandler, query_cache::QueryCache,
     },
-    vex::id::VexId,
 };
 
 #[derive(Debug, derive_more::Display, NoSerialize, ProvidesStaticType, Allocative)]
@@ -78,7 +77,6 @@ impl<'v> StarlarkValue<'v> for ObserverData {}
 
 #[derive(new, Debug, Trace, Allocative)]
 pub struct UnfrozenObserver<'v> {
-    vex_id: VexId,
     callback: Value<'v>,
 }
 
@@ -86,15 +84,14 @@ impl<'v> Freeze for UnfrozenObserver<'v> {
     type Frozen = Observer;
 
     fn freeze(self, freezer: &Freezer) -> anyhow::Result<Self::Frozen> {
-        let Self { vex_id, callback } = self;
+        let Self { callback } = self;
         let callback = callback.freeze(freezer)?;
-        Ok(Observer { vex_id, callback })
+        Ok(Observer { callback })
     }
 }
 
 #[derive(new, Debug, Clone, Dupe, Allocative)]
 pub struct Observer {
-    vex_id: VexId,
     callback: FrozenValue,
 }
 
@@ -124,7 +121,6 @@ impl Observable for Observer {
         let temp_data = TempData {
             action: opts.action,
             query_cache: opts.query_cache,
-            vex_id: self.vex_id.dupe(),
             ignore_markers: opts.ignore_markers,
         };
         let print_handler = PrintHandler::new(opts.action.name());

--- a/src/scriptlets/store.rs
+++ b/src/scriptlets/store.rs
@@ -348,10 +348,6 @@ impl InitingStore {
             frozen_heap,
         })
     }
-
-    pub fn vexes(&self) -> impl Iterator<Item = &InitingScriptlet> {
-        self.store.iter().filter(|s| s.is_vex())
-    }
 }
 
 #[derive(Debug)]

--- a/src/source_file.rs
+++ b/src/source_file.rs
@@ -155,14 +155,12 @@ impl ParsedSourceFile {
                         }
                         RecoverableResult::Err(err) => return Err(err),
                     };
-                    if filter.is_empty() {
-                        if log_enabled!(log::Level::Warn) {
-                            warn!(
-                                "{}:{}: no vex ids specified",
-                                self.path,
-                                Location::of(&Node::new(node, self)),
-                            )
-                        }
+                    if filter.is_empty() && log_enabled!(log::Level::Warn) {
+                        warn!(
+                            "{}:{}: no vex ids specified",
+                            self.path,
+                            Location::of(&Node::new(node, self)),
+                        )
                     }
                     filter
                 };

--- a/src/source_file.rs
+++ b/src/source_file.rs
@@ -149,14 +149,16 @@ impl ParsedSourceFile {
                             }
                             filter
                         }
-                        RecoverableResult::Recovered(filter, err) => {
+                        RecoverableResult::Recovered(filter, errs) => {
                             if log_enabled!(log::Level::Warn) {
-                                warn!(
-                                    "{}:{}: {}",
-                                    self.path,
-                                    Location::of(&Node::new(node, self)),
-                                    err
-                                )
+                                for err in errs {
+                                    warn!(
+                                        "{}:{}: {}",
+                                        self.path,
+                                        Location::of(&Node::new(node, self)),
+                                        err
+                                    );
+                                }
                             }
                             filter
                         }

--- a/src/vex/id.rs
+++ b/src/vex/id.rs
@@ -42,13 +42,13 @@ impl TryFrom<String> for VexId {
 
         const MIN_ID_LEN: usize = 3;
         const MAX_ID_LEN: usize = 25;
-        if raw_id.len() <= MIN_ID_LEN {
+        if raw_id.len() < MIN_ID_LEN {
             return Err(invalid_id(InvalidIDReason::TooShort {
                 len: raw_id.len(),
                 min_len: MIN_ID_LEN,
             }));
         }
-        if raw_id.len() >= MAX_ID_LEN {
+        if raw_id.len() > MAX_ID_LEN {
             return Err(invalid_id(InvalidIDReason::TooLong {
                 len: raw_id.len(),
                 max_len: MAX_ID_LEN,

--- a/src/vex/id.rs
+++ b/src/vex/id.rs
@@ -1,52 +1,41 @@
 use std::{
-    borrow::Borrow, cmp::Ordering, collections::BTreeMap, fmt::Display, ops::RangeTo, sync::Mutex,
+    cmp::Ordering,
+    collections::hash_map::DefaultHasher,
+    fmt::Display,
+    hash::{Hash, Hasher},
 };
 
 use allocative::Allocative;
-use dupe::{Dupe, OptionDupedExt};
 use lazy_static::lazy_static;
 use regex::Regex;
 use serde::Serialize;
 
-use crate::{error::{Error, InvalidIDReason}};
+use crate::error::{Error, InvalidIDReason};
 
-#[derive(Copy, Clone, Debug, Allocative, Dupe)]
-pub struct VexId(usize);
+// TODO(kcza): rename this to IrritationID
+#[derive(Debug, Clone, Allocative, Eq, PartialEq, Serialize)]
+pub struct VexId {
+    hash: u64,
 
-static ID_STORE: Mutex<IdStore> = Mutex::new(IdStore::new());
+    #[allocative(skip)]
+    name: String, // TODO(kcza): Cow this
+}
 
 impl VexId {
-    pub fn new(path: PrettyPath) -> Self {
-        ID_STORE
-            .lock()
-            .expect("internal error: failed to lock ID store")
-            .create_id(path)
-    }
-
-    pub fn retrieve(pretty: &PrettyVexId) -> Option<Self> {
-        Self::retrieve_str(pretty.as_str())
-    }
-
-    pub fn retrieve_str(raw: &str) -> Option<Self> {
-        ID_STORE
-            .lock()
-            .expect("internal error: failed to lock ID store")
-            .get_id(raw)
-    }
-    
-    pub fn to_pretty(self) -> PrettyVexId {
-        ID_STORE
-            .lock()
-            .expect("internal error: failed to lock ID store")
-            .get_pretty_id(self)
-            .expect("internal error: invalid ID")
+    fn new_raw(name: String) -> Self {
+        let hash = {
+            let mut hasher = DefaultHasher::new();
+            name.hash(&mut hasher);
+            hasher.finish()
+        };
+        Self { hash, name }
     }
 }
 
-impl<'i> TryFrom<&'i str> for VexId<'i> {
+impl TryFrom<String> for VexId {
     type Error = Error;
 
-    fn try_from(raw_id: &'i str) -> Result<Self, Self::Error> {
+    fn try_from(raw_id: String) -> Result<Self, Self::Error> {
         let invalid_id = |reason| Error::InvalidID {
             raw_id: raw_id.to_string(),
             reason,
@@ -70,7 +59,7 @@ impl<'i> TryFrom<&'i str> for VexId<'i> {
         lazy_static! {
             static ref VALID_VEX_ID: Regex = Regex::new("^[a-z0-9:-]*$").unwrap();
         }
-        if !VALID_VEX_ID.is_match(raw_id) {
+        if !VALID_VEX_ID.is_match(&raw_id) {
             return Err(invalid_id(InvalidIDReason::IllegalChar));
         }
         let first_char = raw_id.chars().next().unwrap();
@@ -80,162 +69,52 @@ impl<'i> TryFrom<&'i str> for VexId<'i> {
             }
             _ => {}
         }
-        let last_char = raw_id.chars().rev().next().unwrap();
+        let last_char = raw_id.chars().next_back().unwrap();
         match last_char {
             ':' | '-' => return Err(invalid_id(InvalidIDReason::IllegalEndChar(last_char))),
             _ => {}
         }
 
-        if let Some(index) = raw_id.find("::") {
-            return Err(invalid_id(InvalidIDReason::ContainsDoubleColon { index }));
+        for ugly_substring in ["::", "--", ":-", "-:"] {
+            if let Some(index) = raw_id.find(ugly_substring) {
+                return Err(invalid_id(InvalidIDReason::UglySubstring {
+                    found: ugly_substring.to_string(),
+                    index,
+                }));
+            }
         }
-        if let Some(index) = raw_id.find("--") {
-            return Err(invalid_id(InvalidIDReason::ContainsDoubleDash { index }));
-        }
 
-        Ok(Self::new(raw_id))
+        Ok(Self::new_raw(raw_id))
     }
 }
 
-#[cfg(test)]
-impl VexId {
-    pub fn into_inner(self) -> usize {
-        self.0
+impl Ord for VexId {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.name.cmp(&other.name)
     }
 }
 
-impl PartialEq for VexId {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-
-impl Eq for VexId {}
-
-impl Display for VexId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.to_pretty().fmt(f)
-    }
-}
-
-#[derive(Debug, Clone, Allocative)]
-pub enum PrettyVexId {
-    Raw(String),
-    Path {
-        path: PrettyPath,
-
-        #[allocative(skip)]
-        byte_range: RangeTo<usize>,
-    },
-}
-
-impl PrettyVexId {
-    pub fn from_path(path: PrettyPath) -> Self {
-        let byte_range = if let Some(stripped) = path.as_str().strip_suffix(".star") {
-            ..stripped.len()
-        } else {
-            ..path.as_str().len()
-        };
-        Self::Path { path, byte_range }
-    }
-
-    pub fn from_raw(raw: String) -> Self {
-        Self::Raw(raw)
-    }
-
-    pub fn as_str(&self) -> &str {
-        match self {
-            Self::Raw(s) => s,
-            Self::Path { path, byte_range } => &path.as_str()[*byte_range],
-        }
-    }
-}
-
-impl PartialEq for PrettyVexId {
-    fn eq(&self, other: &Self) -> bool {
-        self.as_str() == other.as_str()
-    }
-}
-
-impl Eq for PrettyVexId {}
-
-impl PartialOrd for PrettyVexId {
+impl PartialOrd for VexId {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl Ord for PrettyVexId {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.as_str().cmp(other.as_str())
+impl Hash for VexId {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        state.write_u64(self.hash);
     }
 }
 
-impl AsRef<str> for PrettyVexId {
+impl AsRef<str> for VexId {
     fn as_ref(&self) -> &str {
-        self.as_str()
+        &self.name
     }
 }
 
-impl Borrow<str> for PrettyVexId {
-    fn borrow(&self) -> &str {
-        self.as_str()
-    }
-}
-
-impl Display for PrettyVexId {
+impl Display for VexId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.as_str().fmt(f)
-    }
-}
-
-impl Serialize for PrettyVexId {
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.serialize_str(self.as_str())
-    }
-}
-
-impl Dupe for PrettyVexId {
-    // Fields:
-    // .path: Dupe
-    // .byte_range: !Dupe but cheap
-}
-
-#[derive(Debug, Default)]
-struct IdStore {
-    id_map: BTreeMap<PrettyVexId, VexId>,
-    pretty_map: Vec<PrettyVexId>,
-}
-
-impl IdStore {
-    pub const fn new() -> Self {
-        Self {
-            id_map: BTreeMap::new(),
-            pretty_map: Vec::new(),
-        }
-    }
-
-    pub fn create_id(&mut self, path: PrettyPath) -> VexId {
-        let Self {
-            ref mut id_map,
-            ref mut pretty_map,
-        } = self;
-        let id = VexId(pretty_map.len());
-        let pretty = PrettyVexId::from_path(path);
-        pretty_map.push(pretty.dupe());
-        id_map.insert(pretty, id);
-        id
-    }
-
-    pub fn get_id(&self, pretty: &str) -> Option<VexId> {
-        self.id_map.get(pretty).duped()
-    }
-
-    pub fn get_pretty_id(&self, id: VexId) -> Option<PrettyVexId> {
-        self.pretty_map.get(id.0).duped()
+        f.write_str(&self.name)
     }
 }
 
@@ -244,17 +123,93 @@ mod test {
     use super::*;
 
     #[test]
-    fn unique_ids() {
-        let path = "foo/bar/baz.star".into();
-        let x = VexId::new(PrettyPath::new(path));
-        let y = VexId::new(PrettyPath::new(path));
-        assert_ne!(x.into_inner(), y.into_inner());
-    }
+    fn try_from() {
+        let check_valid = |raw_id: &str| {
+            assert_eq!(
+                VexId::try_from(raw_id.to_string()).unwrap().as_ref(),
+                raw_id
+            )
+        };
+        check_valid("hello");
+        check_valid("hello1234");
+        check_valid("hello:world:1234");
+        check_valid("hello:world-1234");
 
-    #[test]
-    fn pretty() {
-        let path = "foo/bar/baz.star";
-        let id = VexId::new(PrettyPath::new(path.into()));
-        assert_eq!(id.to_pretty().as_str(), "foo/bar/baz");
+        macro_rules! check_invalid {
+            ($raw_id:literal, $pred:expr $(,)?) => {
+                let Error::InvalidID { raw_id, reason } =
+                    VexId::try_from($raw_id.to_string()).unwrap_err()
+                else {
+                    panic!("incorrect error");
+                };
+                assert_eq!(raw_id, $raw_id);
+                let pred = $pred; // Placate clippy.
+                assert!(pred(reason));
+            };
+        }
+        check_invalid!("", |reason| matches!(
+            reason,
+            InvalidIDReason::TooShort { len: 0, .. }
+        ));
+        check_invalid!("i-am-very-very-very-very-long", |reason| matches!(
+            reason,
+            InvalidIDReason::TooLong { len: 29, .. }
+        ));
+        check_invalid!("asdf_fdas", |reason| matches!(
+            reason,
+            InvalidIDReason::IllegalChar
+        ));
+        check_invalid!("asdf/fdas", |reason| matches!(
+            reason,
+            InvalidIDReason::IllegalChar
+        ));
+        check_invalid!("🏁🏁🏁🏁🏁", |reason| matches!(
+            reason,
+            InvalidIDReason::IllegalChar
+        ));
+        check_invalid!("hello world", |reason| matches!(
+            reason,
+            InvalidIDReason::IllegalChar
+        ));
+        check_invalid!("-hello", |reason| matches!(
+            reason,
+            InvalidIDReason::IllegalStartChar('-')
+        ));
+        check_invalid!(":hello", |reason| matches!(
+            reason,
+            InvalidIDReason::IllegalStartChar(':')
+        ));
+        check_invalid!("5hello", |reason| matches!(
+            reason,
+            InvalidIDReason::IllegalStartChar('5')
+        ));
+        check_invalid!("hello-", |reason| matches!(
+            reason,
+            InvalidIDReason::IllegalEndChar('-')
+        ));
+        check_invalid!("hello:", |reason| matches!(
+            reason,
+            InvalidIDReason::IllegalEndChar(':')
+        ));
+        check_invalid!("hello:", |reason| matches!(
+            reason,
+            InvalidIDReason::IllegalEndChar(':')
+        ));
+        check_invalid!("hello--world", |reason| match reason {
+            InvalidIDReason::UglySubstring { found, .. } => found == "--",
+            _ => false,
+        });
+        check_invalid!("hello:-world", |reason| match reason {
+            InvalidIDReason::UglySubstring { found, .. } => found == ":-",
+            _ => false,
+        });
+        check_invalid!("hello-:world", |reason| match reason {
+            InvalidIDReason::UglySubstring { found, .. } => found == "-:",
+            _ => false,
+        });
+        check_invalid!("hello::world", |reason| match reason {
+            InvalidIDReason::UglySubstring { found, .. } => found == "::",
+            _ => false,
+        });
     }
 }

--- a/src/vex/id.rs
+++ b/src/vex/id.rs
@@ -12,13 +12,12 @@ use serde::Serialize;
 
 use crate::error::{Error, InvalidIDReason};
 
-// TODO(kcza): rename this to IrritationID
 #[derive(Debug, Clone, Allocative, Eq, PartialEq, Serialize)]
 pub struct VexId {
     hash: u64,
 
     #[allocative(skip)]
-    name: String, // TODO(kcza): Cow this
+    name: String,
 }
 
 impl VexId {


### PR DESCRIPTION
This PR plumbs the vex ID passed to `vex.warn` into the stored irritation. It also adds sanitisation for these IDs.
