### PR TITLE
Add quiet output flag

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -24,6 +24,10 @@ pub struct Args {
     #[command(subcommand)]
     pub command: Command,
 
+    /// Use quiet output
+    #[arg(short, global = true)]
+    pub quiet: bool,
+
     /// Use verbose output (-vv very verbose)
     #[arg(short, action=ArgAction::Count, value_name="level", global=true)]
     pub verbosity_level: u8,
@@ -359,6 +363,13 @@ mod test {
     #[test]
     fn no_default() {
         Args::try_parse_from(["vex"]).unwrap_err();
+    }
+
+    #[test]
+    fn quiet() {
+        const CMD: &str = "check";
+        assert!(!Args::try_parse_from(["vex", CMD]).unwrap().quiet);
+        assert!(Args::try_parse_from(["vex", CMD, "-q"]).unwrap().quiet);
     }
 
     #[test]

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -25,6 +25,13 @@ pub fn exit_code() -> ExitCode {
     }
 }
 
+#[macro_export]
+macro_rules! success {
+    ($($arg:tt)+) => {
+        ::log::warn!(custom=true; $($arg)+)
+    };
+}
+
 struct Logger {
     level: Level,
 }

--- a/src/scriptlets/scriptlet.rs
+++ b/src/scriptlets/scriptlet.rs
@@ -703,7 +703,7 @@ mod test {
                 let Self { name, path } = self;
                 let path = path.expect("path not set");
                 eprintln!("running test {name} with {path:?}...");
-                println!(r#"load({}, 'unused') "#, path.quote());
+                eprintln!(r"load({}, 'unused')", path.quote());
 
                 const DIR: &str = "/tmp/vex_project";
                 PreinitingScriptlet::new_from_str(

--- a/src/verbosity.rs
+++ b/src/verbosity.rs
@@ -5,8 +5,11 @@ use crate::cli::Args;
 
 #[derive(Copy, Clone, Debug, Default)]
 pub enum Verbosity {
+    Quiet,
+
     #[default]
     Terse,
+
     Verbose,
     Trace,
 }
@@ -27,6 +30,7 @@ impl TryFrom<u8> for Verbosity {
 impl From<Verbosity> for Level {
     fn from(verbosity: Verbosity) -> Self {
         match verbosity {
+            Verbosity::Quiet => Self::Error,
             Verbosity::Terse => Self::Warn,
             Verbosity::Verbose => Self::Info,
             Verbosity::Trace => Self::Trace,


### PR DESCRIPTION
This PR adds a new flag, `-q` which forces quiet output. In this mode, only errors are output.

This PR also cleans up the output macros to cause `-q` to affect all relevant output.
