### PR TITLE
Drop C and C++ support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1556,26 +1556,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tree-sitter-c"
-version = "0.21.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f956d5351d62652864a4ff3ae861747e7a1940dc96c9998ae400ac0d3ce30427"
-dependencies = [
- "cc",
- "tree-sitter",
-]
-
-[[package]]
-name = "tree-sitter-cpp"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e058d4b9cefb54a8f322b31a1bd3cd306919b70b729523473b5aad8d315a8897"
-dependencies = [
- "cc",
- "tree-sitter",
-]
-
-[[package]]
 name = "tree-sitter-go"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1716,8 +1696,6 @@ dependencies = [
  "thiserror",
  "toml_edit",
  "tree-sitter",
- "tree-sitter-c",
- "tree-sitter-cpp",
  "tree-sitter-go",
  "tree-sitter-python",
  "tree-sitter-rust",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,11 +42,9 @@ tempfile = "3.9.0"
 thiserror = "1.0.51"
 toml_edit = { version = "0.21.0", features = ["serde"] }
 tree-sitter = "0.21.0"
-tree-sitter-c = "0.21"
 tree-sitter-go = "0.21"
 tree-sitter-python = "0.21"
 tree-sitter-rust = "0.21"
-tree-sitter-cpp = "0.21"
 uniquote = "4.0.0"
 textwrap = { version = "0.16.1", default-features = false }
 

--- a/src/associations.rs
+++ b/src/associations.rs
@@ -15,13 +15,6 @@ impl Associations {
     pub fn base() -> Self {
         Self(
             [
-                ("*.[ch]", SupportedLanguage::C),
-                // NOTE: Case-sensitive file systems are not assumed, hence .C and
-                // .H remain unassociated.
-                ("*.[ch]pp", SupportedLanguage::Cpp),
-                ("*.cxx", SupportedLanguage::Cpp),
-                ("*.cc", SupportedLanguage::Cpp),
-                ("*.hh", SupportedLanguage::Cpp),
                 ("*.go", SupportedLanguage::Go),
                 ("*.py", SupportedLanguage::Python),
                 ("*.rs", SupportedLanguage::Rust),
@@ -97,13 +90,6 @@ mod test {
 
     #[test]
     fn base() {
-        Test::file("foo/bar.c").has_association(SupportedLanguage::C);
-        Test::file("foo/bar.h").has_association(SupportedLanguage::C);
-        Test::file("foo/bar.cpp").has_association(SupportedLanguage::Cpp);
-        Test::file("foo/bar.hpp").has_association(SupportedLanguage::Cpp);
-        Test::file("foo/bar.cc").has_association(SupportedLanguage::Cpp);
-        Test::file("foo/bar.hh").has_association(SupportedLanguage::Cpp);
-        Test::file("foo/bar.cxx").has_association(SupportedLanguage::Cpp);
         Test::file("foo/bar.go").has_association(SupportedLanguage::Go);
         Test::file("foo/bar.py").has_association(SupportedLanguage::Python);
         Test::file("foo/bar.rs").has_association(SupportedLanguage::Rust);
@@ -151,13 +137,13 @@ mod test {
     fn ambiguous() {
         let associations = {
             let mut associations = Associations::base();
-            let pattern = RawFilePattern::new("*.c").compile().unwrap();
+            let pattern = RawFilePattern::new("*.shrödinger").compile().unwrap();
             associations.insert(vec![pattern.clone()], SupportedLanguage::Rust);
-            associations.insert(vec![pattern], SupportedLanguage::C);
+            associations.insert(vec![pattern], SupportedLanguage::Go);
             associations
         };
         associations
-            .get_language(&SourcePath::new_in("foo.c".into(), "".into()))
+            .get_language(&SourcePath::new_in("foo.shrödinger".into(), "".into()))
             .unwrap_err();
     }
 

--- a/src/trigger.rs
+++ b/src/trigger.rs
@@ -83,29 +83,6 @@ mod test {
 
         let language_tests = [
             LanguageTest {
-                language: "c",
-                query: "(translation_unit)",
-                files: &[
-                    LanguageTestFile {
-                        path: "main.c",
-                        content: indoc! {r#"
-                            #include <stdio.h>
-                            #include "main.h"
-
-                            void main(void) {
-                                printf("Hello, world!\n");
-                            }
-                        "#},
-                    },
-                    LanguageTestFile {
-                        path: "main.h",
-                        content: indoc! {r#"
-                            void some_prototype(void);
-                        "#},
-                    },
-                ],
-            },
-            LanguageTest {
                 language: "go",
                 query: "(source_file)",
                 files: &[LanguageTestFile {


### PR DESCRIPTION
The current, tree-sitter-based approach is not general enough to deal with C/C++ macros, hence codebases which make copious use of these present a significant challenge for Vex in its current form. Therefore, until it is possible to fearlessly parse these languages, official support must be dropped.

This decision is not final.
