### PR TITLE
Take script content by trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,9 +199,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "camino"
-version = "1.1.7"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0ec6b951b160caa93cc0c7b209e5a3bff7aae9062213451ac99493cd844c239"
+checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
 dependencies = [
  "serde",
 ]
@@ -1129,6 +1129,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schemafy"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1722,6 +1731,17 @@ dependencies = [
  "tree-sitter-python",
  "tree-sitter-rust",
  "uniquote",
+ "walkdir",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -1745,6 +1765,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ license-file = "LICENSE"
 allocative = "0.3.1"
 annotate-snippets = "0.10.0"
 anyhow = "1.0.76"
-camino = { version = "1.1.6", features = ["serde1"] }
+camino = { version = "1.1.9", features = ["serde1"] }
 clap = { version = "4.4.11", features = ["derive", "color", "wrap_help"] }
 const_format = "0.2.32"
 derive-new = "0.6.0"
@@ -49,6 +49,7 @@ tree-sitter-rust = "0.21"
 tree-sitter-cpp = "0.21"
 uniquote = "4.0.0"
 textwrap = { version = "0.16.1", default-features = false }
+walkdir = "2"
 
 [dev-dependencies]
 insta = { version = "1.36.1", features = ["yaml"] }

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.75.0"
+channel = "1.81.0"

--- a/src/dump.rs
+++ b/src/dump.rs
@@ -1,6 +1,6 @@
 use std::env;
 
-use camino::{Utf8Path, Utf8PathBuf};
+use camino::Utf8PathBuf;
 
 use crate::{
     associations::Associations,
@@ -15,7 +15,7 @@ use crate::{
 
 pub fn dump(cmd: DumpCmd) -> Result<()> {
     let cwd = Utf8PathBuf::try_from(env::current_dir().map_err(|e| Error::IO {
-        path: PrettyPath::new(Utf8Path::new(&cmd.path)),
+        path: PrettyPath::new(&cmd.path),
         action: IOAction::Read,
         cause: e,
     })?)?;
@@ -56,7 +56,10 @@ mod test {
     use indoc::indoc;
     use tempfile::TempDir;
 
-    use crate::{cli::Args, source_file::ParsedSourceFile, supported_language::SupportedLanguage};
+    use crate::{
+        cli::Args, source_file::ParsedSourceFile, source_path::PrettyPath,
+        supported_language::SupportedLanguage,
+    };
 
     use super::*;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,13 +1,12 @@
 use std::{fmt, io, num, path, str::Utf8Error};
 
-use camino::Utf8PathBuf;
 use derive_more::Display;
 use joinery::JoinableIterator;
 use strum::IntoEnumIterator;
 
 use crate::{
     query::Query,
-    scriptlets::{action::Action, event::EventKind, LoadStatementModule, Location},
+    scriptlets::{action::Action, event::EventKind, LoadPath, Location},
     source_path::PrettyPath,
     supported_language::SupportedLanguage,
 };
@@ -21,7 +20,7 @@ pub enum Error {
     #[error(
         "already inited in a parent directory {found_root}, to continue regardless, use --force"
     )]
-    AlreadyInited { found_root: Utf8PathBuf },
+    AlreadyInited { found_root: PrettyPath },
 
     #[error("cannot discern language of {path} as multiple patterns match (could be {language} or {other_language})")]
     AmbiguousLanguage {
@@ -84,7 +83,7 @@ pub enum Error {
     NoSuchModule(PrettyPath),
 
     #[error("cannot find vexes directory at {0}")]
-    NoVexesDir(Utf8PathBuf),
+    NoVexesDir(PrettyPath),
 
     #[error("{0} is not a check path")]
     NotACheckPath(PrettyPath),
@@ -237,13 +236,13 @@ pub enum InvalidLoadReason {
 
     #[display(
         fmt = "load path components must be at least {} characters",
-        LoadStatementModule::MIN_COMPONENT_LEN
+        LoadPath::MIN_COMPONENT_LEN
     )]
     TooShortComponent,
 
     #[display(
         fmt = "load path stem must be at least {} characters",
-        LoadStatementModule::MIN_COMPONENT_LEN
+        LoadPath::MIN_COMPONENT_LEN
     )]
     TooShortStem,
 
@@ -262,8 +261,8 @@ pub enum InvalidLoadReason {
     #[display(fmt = "load path cannot contain both `./` and `../`")]
     MixedPathOperators,
 
-    #[display(fmt = "load path cannot be relative")]
-    Relative,
+    #[display(fmt = "load path cannot be outside of the scriptlets directory")]
+    OutsideDirectory,
 
     #[display(fmt = "load path invalid, see docs")] // TODO(kcza): link to spec once public.
     NonSpecific,

--- a/src/error.rs
+++ b/src/error.rs
@@ -261,7 +261,7 @@ pub enum InvalidLoadReason {
     #[display(fmt = "load path cannot contain both `./` and `../`")]
     MixedPathOperators,
 
-    #[display(fmt = "load path cannot be outside of the scriptlets directory")]
+    #[display(fmt = "load path cannot be outside of the vexes directory")]
     OutsideDirectory,
 
     #[display(fmt = "load path invalid, see docs")] // TODO(kcza): link to spec once public.

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,7 @@ use indoc::printdoc;
 use log::{info, log_enabled, trace};
 use scriptlets::InitOptions;
 use source_file::SourceFile;
+use source_path::PrettyPath;
 use strum::IntoEnumIterator;
 use tree_sitter::QueryCursor;
 
@@ -58,7 +59,7 @@ use crate::{
         query_captures::QueryCaptures,
         Observable, ObserveOptions, PreinitOptions, PreinitingStore, PrintHandler, VexingStore,
     },
-    source_path::{PrettyPath, SourcePath},
+    source_path::SourcePath,
     supported_language::SupportedLanguage,
     trigger::FilePattern,
     verbosity::Verbosity,
@@ -134,7 +135,7 @@ fn check(cmd_args: CheckCmd) -> Result<()> {
             verbosity,
         };
         let init_opts = InitOptions { verbosity };
-        PreinitingStore::new(&ctx)?
+        PreinitingStore::new_in_dir(&ctx.vex_dir())?
             .preinit(preinit_opts)?
             .init(init_opts)?
     };
@@ -430,7 +431,7 @@ fn walkdir(
 
 fn init(init_args: InitCmd) -> Result<()> {
     let cwd = Utf8PathBuf::try_from(env::current_dir().map_err(|cause| Error::IO {
-        path: PrettyPath::new(Utf8Path::new(".")),
+        path: PrettyPath::from("."),
         action: IOAction::Read,
         cause,
     })?)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ use cli::{InitCmd, ListCmd, MaxProblems, ToList};
 use dupe::Dupe;
 use indoc::printdoc;
 use log::{info, log_enabled, trace};
-use scriptlets::InitOptions;
+use scriptlets::{source, InitOptions};
 use source_file::SourceFile;
 use source_path::PrettyPath;
 use strum::IntoEnumIterator;
@@ -135,7 +135,7 @@ fn check(cmd_args: CheckCmd) -> Result<()> {
             verbosity,
         };
         let init_opts = InitOptions { verbosity };
-        PreinitingStore::new_in_dir(&ctx.vex_dir())?
+        PreinitingStore::new(&source::sources_in_dir(&ctx.vex_dir())?)?
             .preinit(preinit_opts)?
             .init(init_opts)?
     };

--- a/src/scriptlets.rs
+++ b/src/scriptlets.rs
@@ -11,7 +11,7 @@ mod print_handler;
 pub mod query_cache;
 pub mod query_captures;
 mod scriptlet;
-mod source;
+pub mod source;
 mod store;
 
 pub use self::intents::{Intent, Intents};

--- a/src/scriptlets.rs
+++ b/src/scriptlets.rs
@@ -11,6 +11,7 @@ mod print_handler;
 pub mod query_cache;
 pub mod query_captures;
 mod scriptlet;
+mod source;
 mod store;
 
 pub use self::intents::{Intent, Intents};
@@ -18,5 +19,5 @@ pub use self::node::{Location, Node, NodePrinter, WhitespaceStyle};
 pub use self::observers::{Observable, ObserveOptions, Observer, ObserverData};
 pub use self::print_handler::PrintHandler;
 pub use self::query_captures::QueryCaptures;
-pub use self::scriptlet::LoadStatementModule;
+pub use self::scriptlet::LoadPath;
 pub use self::store::{InitOptions, PreinitOptions, PreinitingStore, VexingStore};

--- a/src/scriptlets/app_object.rs
+++ b/src/scriptlets/app_object.rs
@@ -510,11 +510,11 @@ mod test {
         let irritations = VexTest::new("many-origins")
             .with_scriptlet(
                 format!("vexes/{}.star", VEX_2_FILE_NAME),
-                &vex_source(VEX_2_NAME),
+                vex_source(VEX_2_NAME),
             )
             .with_scriptlet(
                 format!("vexes/{}.star", VEX_1_FILE_NAME),
-                &vex_source(VEX_1_NAME),
+                vex_source(VEX_1_NAME),
             )
             .with_source_file(
                 "src/main.rs",

--- a/src/scriptlets/scriptlet.rs
+++ b/src/scriptlets/scriptlet.rs
@@ -295,7 +295,7 @@ impl LoadPath {
             reason,
         };
 
-        let dir = from.parent().unwrap_or(&Utf8Path::new(""));
+        let dir = from.parent().unwrap_or(Utf8Path::new(""));
         let mut clean_path_components = Vec::with_capacity(10);
         for component in dir.components().chain(Utf8Path::new(load).components()) {
             match component {

--- a/src/scriptlets/scriptlet.rs
+++ b/src/scriptlets/scriptlet.rs
@@ -132,13 +132,11 @@ impl LoadPath {
     fn new(from: &Utf8Path, load: &str) -> Result<Self> {
         let load_path = Utf8Path::new(load);
         Self::validate_raw(from, load_path)?;
-        let resolved_path = if matches!(
-            load_path.components().next(),
-            Some(Utf8Component::CurDir) | Some(Utf8Component::ParentDir)
-        ) {
-            Self::path_in_dir(from, load)?
-        } else {
-            load_path.to_owned()
+        let resolved_path = match load_path.components().next() {
+            Some(Utf8Component::CurDir | Utf8Component::ParentDir) => {
+                Self::path_in_dir(from, load)?
+            }
+            _ => load_path.to_owned(),
         };
         Ok(Self(resolved_path))
     }

--- a/src/scriptlets/source.rs
+++ b/src/scriptlets/source.rs
@@ -1,0 +1,73 @@
+use std::{
+    fs::{self, File},
+    io::Read,
+};
+
+use crate::{
+    error::{Error, IOAction},
+    result::Result,
+    source_path::PrettyPath,
+};
+use camino::{Utf8Path, Utf8PathBuf};
+use log::{info, log_enabled};
+
+pub trait ScriptSource {
+    fn path(&self) -> &Utf8Path;
+    fn content(&self) -> Result<String>;
+}
+
+#[derive(Debug)]
+pub struct FileSource {
+    load_path: Utf8PathBuf,
+    path: Utf8PathBuf,
+}
+
+impl FileSource {
+    pub fn new(load_path: Utf8PathBuf, path: Utf8PathBuf) -> Self {
+        Self { load_path, path }
+    }
+}
+
+impl ScriptSource for FileSource {
+    fn path(&self) -> &Utf8Path {
+        &self.load_path
+    }
+
+    fn content(&self) -> Result<String> {
+        let io_error = |cause| Error::IO {
+            path: PrettyPath::new(&self.path),
+            action: IOAction::Read,
+            cause,
+        };
+
+        let metadata = fs::symlink_metadata(&self.path).map_err(io_error)?;
+        if !metadata.is_file() && log_enabled!(log::Level::Info) {
+            info!("ignoring {}: not a regular file", self.path)
+        }
+
+        let mut file = File::open(&self.path).map_err(io_error)?;
+        let mut content = String::with_capacity(metadata.len().try_into().expect("file too large"));
+        file.read_to_string(&mut content).map_err(io_error)?;
+        Ok(content)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    pub struct TestSource<S: AsRef<str>> {
+        pub path: S,
+        pub content: S,
+    }
+
+    impl<S: AsRef<str>> ScriptSource for TestSource<S> {
+        fn path(&self) -> &Utf8Path {
+            self.path.as_ref().into()
+        }
+
+        fn content(&self) -> Result<String> {
+            Ok(self.content.as_ref().to_owned())
+        }
+    }
+}

--- a/src/scriptlets/source.rs
+++ b/src/scriptlets/source.rs
@@ -3,28 +3,33 @@ use std::{
     io::Read,
 };
 
+use camino::{Utf8Path, Utf8PathBuf};
+use log::{info, log_enabled};
+use walkdir::WalkDir;
+
 use crate::{
     error::{Error, IOAction},
     result::Result,
     source_path::PrettyPath,
 };
-use camino::{Utf8Path, Utf8PathBuf};
-use log::{info, log_enabled};
 
 pub trait ScriptSource {
     fn path(&self) -> &Utf8Path;
     fn content(&self) -> Result<String>;
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct FileSource {
     load_path: Utf8PathBuf,
-    path: Utf8PathBuf,
+    real_path: Utf8PathBuf,
 }
 
 impl FileSource {
-    pub fn new(load_path: Utf8PathBuf, path: Utf8PathBuf) -> Self {
-        Self { load_path, path }
+    pub fn new(load_path: Utf8PathBuf, real_path: Utf8PathBuf) -> Self {
+        Self {
+            load_path,
+            real_path,
+        }
     }
 }
 
@@ -35,39 +40,98 @@ impl ScriptSource for FileSource {
 
     fn content(&self) -> Result<String> {
         let io_error = |cause| Error::IO {
-            path: PrettyPath::new(&self.path),
+            path: PrettyPath::new(&self.load_path),
             action: IOAction::Read,
             cause,
         };
 
-        let metadata = fs::symlink_metadata(&self.path).map_err(io_error)?;
+        let metadata = fs::symlink_metadata(&self.real_path).map_err(io_error)?;
         if !metadata.is_file() && log_enabled!(log::Level::Info) {
-            info!("ignoring {}: not a regular file", self.path)
+            info!("ignoring {}: not a regular file", self.real_path)
         }
 
-        let mut file = File::open(&self.path).map_err(io_error)?;
+        let mut file = File::open(&self.real_path).map_err(io_error)?;
         let mut content = String::with_capacity(metadata.len().try_into().expect("file too large"));
         file.read_to_string(&mut content).map_err(io_error)?;
         Ok(content)
     }
 }
 
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    pub struct TestSource<S: AsRef<str>> {
-        pub path: S,
-        pub content: S,
+pub fn sources_in_dir(dir_path: &Utf8Path) -> Result<Vec<FileSource>> {
+    if !dir_path.is_dir() {
+        return Err(Error::NoVexesDir(PrettyPath::new(dir_path)));
     }
 
-    impl<S: AsRef<str>> ScriptSource for TestSource<S> {
-        fn path(&self) -> &Utf8Path {
-            self.path.as_ref().into()
-        }
+    let dir_walker = WalkDir::new(dir_path)
+        .sort_by_file_name()
+        .min_depth(1) // Immediate children.
+        .into_iter()
+        .filter_entry(|entry| {
+            entry.file_type().is_dir() || entry.path().extension().is_some_and(|ext| ext == "star")
+        });
+    let sources: Vec<_> = dir_walker
+        .flatten() // Ignore inaccessible files.
+        .filter(|entry| entry.file_type().is_file())
+        .flat_map(|entry| Utf8PathBuf::try_from(entry.into_path()))
+        .map(|path| {
+            let load_path = path.strip_prefix(dir_path).unwrap_or(&path).to_owned();
+            FileSource::new(load_path, path)
+        })
+        .collect();
+    Ok(sources)
+}
 
-        fn content(&self) -> Result<String> {
-            Ok(self.content.as_ref().to_owned())
-        }
+#[cfg(test)]
+pub struct TestSource<P, C> {
+    pub vex_dir: P,
+    pub path: P,
+    pub content: C,
+}
+
+#[cfg(test)]
+impl<P, C> ScriptSource for TestSource<P, C>
+where
+    P: AsRef<Utf8Path>,
+    C: AsRef<str>,
+{
+    fn path(&self) -> &Utf8Path {
+        self.path
+            .as_ref()
+            .strip_prefix(self.vex_dir.as_ref())
+            .unwrap()
+    }
+
+    fn content(&self) -> Result<String> {
+        Ok(self.content.as_ref().to_owned())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::io::Write;
+
+    use regex::Regex;
+
+    use crate::scriptlets::source;
+
+    use super::*;
+
+    #[test]
+    fn no_vexes_dir() -> Result<()> {
+        let tempdir = tempfile::tempdir().unwrap();
+        let tempdir_path = Utf8PathBuf::try_from(tempdir.path().to_owned())?;
+
+        let mut manifest = File::create(tempdir_path.join("vex.toml")).unwrap();
+        manifest.write_all("[vex]".as_bytes()).unwrap();
+
+        let re = Regex::new("^cannot find vexes directory at .*").unwrap();
+        let err = source::sources_in_dir("i-do-not-exist".into()).unwrap_err();
+        assert!(
+            re.is_match(&err.to_string()),
+            "incorrect error, expected {} but got {err}",
+            re.as_str()
+        );
+
+        Ok(())
     }
 }

--- a/src/scriptlets/store.rs
+++ b/src/scriptlets/store.rs
@@ -45,7 +45,7 @@ impl PreinitingStore {
 
     pub fn preinit(mut self, opts: PreinitOptions) -> Result<InitingStore> {
         self.store.sort_by(|sc1, sc2| sc1.path.cmp(&sc2.path));
-        self.sort_topographically()?;
+        self.topographic_sort()?;
         let Self { store } = self;
 
         let frozen_heap = FrozenHeap::new();
@@ -60,7 +60,7 @@ impl PreinitingStore {
     }
 
     /// Topographically order the store
-    fn sort_topographically(&mut self) -> Result<()> {
+    fn topographic_sort(&mut self) -> Result<()> {
         fn directed_dfs(
             linearised: &mut Vec<StoreIndex>,
             explored: &mut [bool],

--- a/src/scriptlets/store.rs
+++ b/src/scriptlets/store.rs
@@ -1,169 +1,107 @@
-use std::{collections::BTreeMap, fs, io::ErrorKind, iter, ops::Deref};
+use std::{collections::BTreeMap, ops::Deref};
 
-use camino::Utf8PathBuf;
+use camino::{Utf8Path, Utf8PathBuf};
 use dupe::Dupe;
 use log::{info, log_enabled};
-use starlark::{environment::FrozenModule, eval::FileLoader, values::FrozenHeap};
+use starlark::{eval::FileLoader, values::FrozenHeap};
+use walkdir::WalkDir;
 
 use crate::{
-    context::Context,
-    error::{Error, IOAction},
+    error::Error,
     result::Result,
     scriptlets::{
         scriptlet::{InitingScriptlet, PreinitingScriptlet},
+        source::{FileSource, ScriptSource},
         ObserverData,
     },
-    source_path::{PrettyPath, SourcePath},
+    source_path::PrettyPath,
     verbosity::Verbosity,
 };
 
-type StoreIndex = usize;
-
 #[derive(Debug)]
 pub struct PreinitingStore {
-    vex_dir: Utf8PathBuf,
-    path_indices: BTreeMap<PrettyPath, StoreIndex>,
     store: Vec<PreinitingScriptlet>,
 }
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+struct StoreIndex(usize);
+
 impl PreinitingStore {
-    pub fn new(ctx: &Context) -> Result<Self> {
-        let mut ret = Self {
-            vex_dir: ctx.vex_dir(),
-            path_indices: BTreeMap::new(),
-            store: Vec::new(),
-        };
-        ret.load_dir(ctx, ctx.vex_dir())?;
-        Ok(ret)
+    pub fn new<S: ScriptSource>(scripts: Vec<S>) -> Result<Self> {
+        let store: Vec<_> = scripts
+            .iter()
+            .map(|source| Result::Ok((source.path(), source.content()?)))
+            .inspect(|content_result| {
+                if let Err(err) = content_result {
+                    if log_enabled!(log::Level::Info) {
+                        info!("{err}");
+                    }
+                }
+            })
+            .flatten()
+            .map(|(path, content)| PreinitingScriptlet::new(path.to_owned(), content))
+            .collect::<Result<_>>()?;
+        Ok(Self { store })
     }
 
-    fn load_dir(&mut self, ctx: &Context, path: Utf8PathBuf) -> Result<()> {
-        let dir = fs::read_dir(&path).map_err(|err| match err.kind() {
-            ErrorKind::NotFound => Error::NoVexesDir(path.clone()),
-            _ => Error::IO {
-                path: PrettyPath::new(&path),
-                action: IOAction::Read,
-                cause: err,
-            },
-        })?;
-        for entry in dir {
-            let entry = entry.map_err(|cause| Error::IO {
-                path: PrettyPath::new(&path),
-                action: IOAction::Read,
-                cause,
-            })?;
-            let entry_path = Utf8PathBuf::try_from(entry.path())?;
-            let metadata = fs::symlink_metadata(&entry_path).map_err(|cause| Error::IO {
-                path: PrettyPath::new(&entry_path),
-                action: IOAction::Read,
-                cause,
-            })?;
-
-            if metadata.is_symlink() {
-                if log_enabled!(log::Level::Info) {
-                    let symlink_path = entry_path.strip_prefix(ctx.project_root.as_ref())?;
-                    info!("ignoring /{symlink_path} (symlink)");
-                }
-                continue;
-            }
-
-            if metadata.is_dir() {
-                self.load_dir(ctx, entry_path)?;
-                continue;
-            }
-
-            if !metadata.is_file() {
-                panic!("unreachable");
-            }
-            if !entry_path.extension().is_some_and(|ext| ext == "star") {
-                if log_enabled!(log::Level::Info) {
-                    let unknown_path = entry_path.strip_prefix(ctx.project_root.as_ref())?;
-                    info!("ignoring /{unknown_path} (expected `.star` extension)");
-                }
-                continue;
-            }
-            let scriptlet_path = SourcePath::new(&entry_path, &self.vex_dir);
-            self.load_file(scriptlet_path)?;
+    pub fn new_in_dir(dir_path: &Utf8Path) -> Result<Self> {
+        if !dir_path.is_dir() {
+            return Err(Error::NoVexesDir(PrettyPath::new(dir_path)));
         }
 
-        Ok(())
-    }
-
-    fn load_file(&mut self, path: SourcePath) -> Result<()> {
-        if self.path_indices.get(&path.pretty_path).is_some() {
-            return Ok(());
-        }
-
-        let scriptlet = PreinitingScriptlet::new(path.dupe())?;
-        self.store.push(scriptlet);
-        self.path_indices
-            .insert(path.pretty_path.dupe(), self.store.len() - 1);
-
-        Ok(())
+        let dir_walker = WalkDir::new(dir_path)
+            // .sort_by_file_name()
+            .min_depth(1) // Immediate children.
+            .into_iter()
+            .filter_entry(|entry| {
+                entry.file_type().is_dir()
+                    || entry.path().extension().is_some_and(|ext| ext == "star")
+            });
+        let sources: Vec<_> = dir_walker
+            .flatten() // Ignore inaccessible files.
+            .filter(|entry| entry.file_type().is_file())
+            .map(|entry| Utf8PathBuf::try_from(entry.into_path()))
+            .flatten() // Ignore files with invalid UTF-8 file names.
+            .map(|path| {
+                let load_path = path.strip_prefix(dir_path).unwrap_or(&path).to_owned();
+                FileSource::new(load_path, path)
+            })
+            .collect();
+        Self::new(sources)
     }
 
     pub fn preinit(mut self, opts: PreinitOptions) -> Result<InitingStore> {
-        self.check_loads()?;
-        self.sort();
-        self.linearise_store()?;
-
-        let Self { store, .. } = self;
+        self.store.sort_by(|sc1, sc2| sc1.path.cmp(&sc2.path));
+        self.sort_topographically()?;
+        let Self { store } = self;
 
         let frozen_heap = FrozenHeap::new();
-        let mut initing_store = Vec::with_capacity(store.len());
-        let mut cache = PreinitedModuleCache::new();
+        let mut cache = PreinitedModuleStore::new();
         for scriptlet in store.into_iter() {
             let preinited_scriptlet = scriptlet.preinit(&opts, &cache, &frozen_heap)?;
-            cache.cache(&preinited_scriptlet);
-            initing_store.push(preinited_scriptlet);
+            cache.store(preinited_scriptlet);
         }
 
-        Ok(InitingStore {
-            store: initing_store,
-            frozen_heap,
-        })
-    }
-
-    fn check_loads(&self) -> Result<()> {
-        // TODO(kcza): use relative loads
-        let mut unknown_loads = self.store.iter().flat_map(|s| {
-            s.loads()
-                .iter()
-                .filter(|l| self.path_indices.get(l).is_none())
-        });
-        if let Some(unknown_module) = unknown_loads.next() {
-            return Err(Error::NoSuchModule(unknown_module.dupe()));
-        }
-        Ok(())
-    }
-
-    fn sort(&mut self) {
-        self.store
-            .sort_by(|s, t| s.path.pretty_path.cmp(&t.path.pretty_path));
-        self.path_indices = self
-            .store
-            .iter()
-            .enumerate()
-            .map(|(i, s)| (s.path.pretty_path.dupe(), i))
-            .collect();
+        let store = cache.into_entry_modules().collect();
+        Ok(InitingStore { store, frozen_heap })
     }
 
     /// Topographically order the store
-    fn linearise_store(&mut self) -> Result<()> {
+    fn sort_topographically(&mut self) -> Result<()> {
         fn directed_dfs(
             linearised: &mut Vec<StoreIndex>,
-            explored: &mut Vec<bool>,
+            explored: &mut [bool],
             loads: &[Vec<StoreIndex>],
             loaded_by: &[Vec<StoreIndex>],
             node: StoreIndex,
         ) {
-            if !loads[node].iter().all(|n| explored[*n]) {
+            if !loads[node.0].iter().all(|n| explored[n.0]) {
                 return;
             }
 
-            explored[node] = true;
+            explored[node.0] = true;
             linearised.push(node);
-            for m in &loaded_by[node] {
+            for m in &loaded_by[node.0] {
                 directed_dfs(linearised, explored, loads, loaded_by, *m);
             }
         }
@@ -173,8 +111,8 @@ impl PreinitingStore {
         let n = self.store.len();
         let mut explored = vec![false; n];
         let mut linearised = Vec::with_capacity(n);
-        for node in 0..n {
-            if explored[node] {
+        for node in (0..n).map(StoreIndex) {
+            if explored[node.0] {
                 continue;
             }
 
@@ -194,8 +132,8 @@ impl PreinitingStore {
         linearised
             .into_iter()
             .enumerate()
-            .filter(|(i, j)| i < j)
-            .for_each(|(i, j)| self.store.swap(i, j));
+            .filter(|(i, j)| *i < j.0)
+            .for_each(|(i, j)| self.store.swap(i, j.0));
 
         Ok(())
     }
@@ -203,7 +141,7 @@ impl PreinitingStore {
     fn find_cycle(&self) -> Vec<PrettyPath> {
         fn undirected_dfs(
             stack: &mut Vec<StoreIndex>,
-            explored: &mut Vec<bool>,
+            explored: &mut [bool],
             edges: &[Vec<StoreIndex>],
             node: StoreIndex,
         ) -> Option<Vec<StoreIndex>> {
@@ -218,13 +156,13 @@ impl PreinitingStore {
                 );
             }
 
-            if explored[node] {
+            if explored[node.0] {
                 return None;
             }
-            explored[node] = true;
+            explored[node.0] = true;
 
             stack.push(node);
-            for next in &edges[node] {
+            for next in &edges[node.0] {
                 let r = undirected_dfs(stack, explored, edges, *next);
                 if r.is_some() {
                     return r;
@@ -241,13 +179,13 @@ impl PreinitingStore {
             self.get_loaded_by_edges(&edges)
                 .into_iter()
                 .enumerate()
-                .for_each(|(n, g)| g.iter().for_each(|m| edges[*m].push(n)));
+                .for_each(|(n, g)| g.into_iter().for_each(|m| edges[m.0].push(StoreIndex(n))));
             edges
         };
         let n = self.store.len();
         let mut explored = vec![false; n];
         let mut cycle = None;
-        for node in 0..n {
+        for node in (0..n).map(StoreIndex) {
             let c = undirected_dfs(&mut stack, &mut explored, &edges, node);
             if c.is_some() {
                 cycle = c;
@@ -257,34 +195,37 @@ impl PreinitingStore {
         cycle
             .unwrap()
             .into_iter()
-            .map(|idx| self.store[idx].path.pretty_path.dupe())
+            .map(|idx| PrettyPath::new(&self.store[idx.0].path))
             .collect()
     }
 
     fn get_load_edges(&self) -> Vec<Vec<StoreIndex>> {
+        let script_indices_by_path: BTreeMap<_, _> = self
+            .store
+            .iter()
+            .enumerate()
+            .map(|(idx, script)| (script.path.as_path(), StoreIndex(idx)))
+            .collect();
         self.store
             .iter()
-            .map(|s| {
-                let mut adjacent = s
+            .map(|script| {
+                script
                     .loads()
-                    .iter()
-                    .map(|m| *self.path_indices.get(m).unwrap())
-                    .collect::<Vec<_>>();
-                adjacent.sort();
-                adjacent
+                    .values()
+                    .map(|load| script_indices_by_path.get(load.path()).map(|idx| *idx))
+                    .flatten()
+                    .collect()
             })
             .collect()
     }
 
     fn get_loaded_by_edges(&self, load_edges: &[Vec<StoreIndex>]) -> Vec<Vec<StoreIndex>> {
-        let mut ret = iter::repeat_with(Vec::new)
-            .take(self.store.len())
-            .collect::<Vec<_>>();
-        load_edges
-            .iter()
-            .enumerate()
-            .rev()
-            .for_each(|(n, a)| a.iter().for_each(|m| ret[*m].push(n)));
+        let mut ret = vec![Vec::new(); load_edges.len()];
+        for (idx, loads) in load_edges.iter().enumerate() {
+            for load_idx in loads {
+                ret[load_idx.0].push(StoreIndex(idx));
+            }
+        }
         ret
     }
 }
@@ -296,32 +237,32 @@ pub struct PreinitOptions {
 }
 
 #[derive(Debug)]
-pub struct PreinitedModuleCache {
-    exports: BTreeMap<PrettyPath, FrozenModule>,
+pub struct PreinitedModuleStore {
+    entries: BTreeMap<Utf8PathBuf, InitingScriptlet>,
 }
 
-impl PreinitedModuleCache {
+impl PreinitedModuleStore {
     fn new() -> Self {
         Self {
-            exports: BTreeMap::new(),
+            entries: BTreeMap::new(),
         }
     }
 
-    fn cache(&mut self, scriptlet: &InitingScriptlet) {
-        self.exports.insert(
-            scriptlet.path.pretty_path.dupe(),
-            scriptlet.preinited_module.dupe(),
-        );
+    fn store(&mut self, scriptlet: InitingScriptlet) {
+        self.entries.insert(scriptlet.path.to_owned(), scriptlet);
+    }
+
+    pub fn into_entry_modules(self) -> impl Iterator<Item = InitingScriptlet> {
+        self.entries.into_iter().map(|(_, module)| module)
     }
 }
 
-impl FileLoader for &PreinitedModuleCache {
+impl FileLoader for &PreinitedModuleStore {
     fn load(&self, path: &str) -> anyhow::Result<starlark::environment::FrozenModule> {
-        let path = PrettyPath::from(path);
-        self.exports
-            .get(&path)
-            .map(Dupe::dupe)
-            .ok_or_else(|| Error::NoSuchModule(path).into())
+        self.entries
+            .get(Utf8Path::new(path))
+            .map(|scriptlet| scriptlet.preinited_module.dupe())
+            .ok_or_else(|| Error::NoSuchModule(path.into()).into())
     }
 }
 
@@ -340,7 +281,7 @@ impl InitingStore {
             ObserverData::with_capacity(4 * num_scripts),
             |mut data, scriptlet| {
                 data.extend(scriptlet.init(&opts, &frozen_heap)?);
-                Ok::<_, Error>(data)
+                Result::Ok(data)
             },
         )?;
 

--- a/src/source_path.rs
+++ b/src/source_path.rs
@@ -37,10 +37,6 @@ impl SourcePath {
             pretty_path: PrettyPath::new(path),
         }
     }
-
-    // pub fn as_str(&self) -> &str {
-    //     self.pretty_path.as_str()
-    // }
 }
 
 impl AsRef<str> for SourcePath {

--- a/src/source_path.rs
+++ b/src/source_path.rs
@@ -38,9 +38,9 @@ impl SourcePath {
         }
     }
 
-    pub fn as_str(&self) -> &str {
-        self.pretty_path.as_str()
-    }
+    // pub fn as_str(&self) -> &str {
+    //     self.pretty_path.as_str()
+    // }
 }
 
 impl AsRef<str> for SourcePath {
@@ -342,8 +342,7 @@ mod test {
     impl FileLoader for TestModuleCache {
         fn load(&self, path: &str) -> anyhow::Result<starlark::environment::FrozenModule> {
             if path != VexTest::CHECK_STARLARK_PATH {
-                let path = PrettyPath::from(path);
-                return Err(Error::NoSuchModule(path).into());
+                return Err(Error::NoSuchModule(path.into()).into());
             }
             lazy_static! {
                 static ref CHECK_MODULE: FrozenModule = {

--- a/src/test.rs
+++ b/src/test.rs
@@ -39,7 +39,7 @@ pub fn test() -> Result<()> {
         let init_opts = InitOptions {
             verbosity: Verbosity::Quiet,
         };
-        PreinitingStore::new(&ctx)?
+        PreinitingStore::new_in_dir(&ctx.vex_dir())?
             .preinit(preinit_opts)?
             .init(init_opts)?
     };
@@ -162,7 +162,7 @@ pub(crate) fn run_tests(ctx: &Context, store: &VexingStore) -> Result<()> {
             let preinit_opts = PreinitOptions { lenient, verbosity };
             let init_opts = InitOptions { verbosity };
             // Create new store using the current context to inherit the existing scripts.
-            PreinitingStore::new(ctx)?
+            PreinitingStore::new_in_dir(&ctx.vex_dir())?
                 .preinit(preinit_opts)?
                 .init(init_opts)?
         };

--- a/src/test.rs
+++ b/src/test.rs
@@ -32,7 +32,6 @@ use crate::{
 
 pub fn test() -> Result<()> {
     let ctx = Context::acquire()?;
-
     run_tests(&source::sources_in_dir(&ctx.vex_dir())?)
 }
 

--- a/src/vextest.rs
+++ b/src/vextest.rs
@@ -5,7 +5,7 @@ use std::{
     io::Write,
 };
 
-use camino::Utf8PathBuf;
+use camino::{Utf8Component, Utf8PathBuf};
 use indoc::indoc;
 use regex::Regex;
 
@@ -13,7 +13,10 @@ use crate::{
     cli::MaxProblems,
     context::Context,
     result::Result,
-    scriptlets::{InitOptions, PreinitOptions, PreinitingStore},
+    scriptlets::{
+        source::{ScriptSource, TestSource},
+        InitOptions, PreinitOptions, PreinitingStore,
+    },
     verbosity::Verbosity,
     RunData,
 };
@@ -27,7 +30,7 @@ pub struct VexTest<'s> {
     max_problems: MaxProblems,
     lenient: bool,
     fire_test_events: bool,
-    scriptlets: BTreeMap<Utf8PathBuf, Cow<'s, str>>,
+    scriptlets: Vec<TestSource<Utf8PathBuf, Cow<'s, str>>>,
     source_files: BTreeMap<Utf8PathBuf, Cow<'s, str>>,
 }
 
@@ -80,13 +83,28 @@ impl<'s> VexTest<'s> {
         let content = content.into();
 
         assert!(
-            path.starts_with("vexes/"),
+            path.as_str().starts_with("vexes/"),
             "test scriptlet path must start with vexes/"
         );
         assert!(
-            self.scriptlets.insert(path, content).is_none(),
+            !self.scriptlets.iter().any(|s| s.path() == path),
             "duplicate scriptlet declaration"
         );
+        let vex_dir = path
+            .components()
+            .next()
+            .and_then(|first| match first {
+                Utf8Component::Normal(d) => Some(d),
+                _ => None,
+            })
+            .unwrap()
+            .to_owned()
+            .into();
+        self.scriptlets.push(TestSource {
+            vex_dir,
+            path,
+            content,
+        });
     }
 
     #[allow(unused)]
@@ -136,41 +154,32 @@ impl<'s> VexTest<'s> {
                 .unwrap();
         }
 
-        for (path, content) in &self.scriptlets {
-            let scriptlet_path = root_path.join(path);
-            fs::create_dir_all(scriptlet_path.parent().unwrap()).unwrap();
-            File::create(scriptlet_path)
-                .unwrap()
-                .write_all(content.as_bytes())
-                .unwrap();
-        }
-
-        for (path, content) in &self.source_files {
-            let source_path = root_path.join(path);
-            fs::create_dir_all(source_path.parent().unwrap()).unwrap();
-            File::create(root_path.join(path))
-                .unwrap()
-                .write_all(content.as_bytes())
-                .unwrap();
-        }
-
         let ctx = Context::acquire_in(&root_path).unwrap();
         if !self.bare {
             fs::create_dir(ctx.vex_dir()).ok();
         }
-        let verbosity = Verbosity::default();
-        let preinit_opts = PreinitOptions {
-            lenient: self.lenient,
-            verbosity,
-        };
-        let init_opts = InitOptions { verbosity };
-        let store = PreinitingStore::new_in_dir(&ctx.vex_dir())?
-            .preinit(preinit_opts)?
-            .init(init_opts)?;
         if self.fire_test_events {
-            crate::test::run_tests(&ctx, &store)?;
+            crate::test::run_tests(&self.scriptlets)?;
             Ok(RunData::default())
         } else {
+            for (path, content) in &self.source_files {
+                let source_path = root_path.join(path);
+                fs::create_dir_all(source_path.parent().unwrap()).unwrap();
+                File::create(root_path.join(path))
+                    .unwrap()
+                    .write_all(content.as_bytes())
+                    .unwrap();
+            }
+
+            let verbosity = Verbosity::default();
+            let preinit_opts = PreinitOptions {
+                lenient: self.lenient,
+                verbosity,
+            };
+            let init_opts = InitOptions { verbosity };
+            let store = PreinitingStore::new(&self.scriptlets)?
+                .preinit(preinit_opts)?
+                .init(init_opts)?;
             super::vex(&ctx, &store, self.max_problems, verbosity)
         }
     }

--- a/src/vextest.rs
+++ b/src/vextest.rs
@@ -164,7 +164,7 @@ impl<'s> VexTest<'s> {
             verbosity,
         };
         let init_opts = InitOptions { verbosity };
-        let store = PreinitingStore::new(&ctx)?
+        let store = PreinitingStore::new_in_dir(&ctx.vex_dir())?
             .preinit(preinit_opts)?
             .init(init_opts)?;
         if self.fire_test_events {


### PR DESCRIPTION
This PR refactors how script sources are acquired to allow them to be read both from disk and memory. This PR also implements relative loading, as a natural consequence of this.

Further, tests and the `test` subcommand are refactored to avoid using disk
