### PR TITLE
Fix `init --force` commands in already-inited projects

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -193,7 +193,8 @@ impl Manifest {
         let file_path = project_root.join(Self::FILE_NAME);
         let file = File::options()
             .write(true)
-            .create_new(!force)
+            .create(true)
+            .truncate(true)
             .open(&file_path)
             .map_err(|cause| Error::IO {
                 path: PrettyPath::new(&file_path),


### PR DESCRIPTION
This PR fixes an IO error when running `vex init --force` in directories which already contain a manifest
