### PR TITLE
Report number of files scanned before abort

### DIFF
--- a/src/logger.rs
+++ b/src/logger.rs
@@ -113,11 +113,11 @@ impl Log for Logger {
 
 fn annotation_type_of(level: Level) -> AnnotationType {
     match level {
-        Level::Trace => AnnotationType::Note,
         Level::Error => AnnotationType::Error,
-        Level::Info => AnnotationType::Info,
         Level::Warn => AnnotationType::Warning,
+        Level::Info => AnnotationType::Info,
         Level::Debug => AnnotationType::Help,
+        Level::Trace => AnnotationType::Note,
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -155,14 +155,15 @@ fn check(cmd_args: CheckCmd) -> Result<()> {
     }
     if log_enabled!(log::Level::Debug) {
         let pretty_approx = |num| {
-            if num < 1_000 {
+            let num = num as f64;
+            if num < 1_000.0 {
                 format!("{num}")
-            } else if num < 1_000_000 {
-                format!("{:.1}K", num as f64 / 1_000.0)
-            } else if num < 1_000_000_000 {
-                format!("{:.1}M", num as f64 / 1_000_000.0)
+            } else if num < 1_000_000.0 {
+                format!("{:.1}K", num / 1_000.0)
+            } else if num < 1_000_000_000.0 {
+                format!("{:.1}M", num / 1_000_000.0)
             } else {
-                format!("{:.1}G", num as f64 / 1_000_000_000.0)
+                format!("{:.1}G", num / 1_000_000_000.0)
             }
         };
         debug!("scanned {} bytes", pretty_approx(num_bytes_scanned),);

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ use std::{env, process::ExitCode};
 
 use camino::Utf8PathBuf;
 use indoc::{formatdoc, printdoc};
-use log::{info, log_enabled, trace};
+use log::{debug, info, log_enabled};
 use rayon::ThreadPoolBuilder;
 use strum::IntoEnumIterator;
 
@@ -153,7 +153,7 @@ fn check(cmd_args: CheckCmd) -> Result<()> {
             Plural::new(num_files_scanned, "file", "files"),
         );
     }
-    if log_enabled!(log::Level::Trace) {
+    if log_enabled!(log::Level::Debug) {
         let pretty_approx = |num| {
             if num < 1_000 {
                 format!("{num}")
@@ -165,7 +165,7 @@ fn check(cmd_args: CheckCmd) -> Result<()> {
                 format!("{:.1}G", num as f64 / 1_000_000_000.0)
             }
         };
-        trace!("scanned {} bytes", pretty_approx(num_bytes_scanned),);
+        debug!("scanned {} bytes", pretty_approx(num_bytes_scanned),);
     }
 
     let num_problems = irritations.len()

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ use std::{env, process::ExitCode};
 
 use camino::Utf8PathBuf;
 use indoc::{formatdoc, printdoc};
-use log::{info, log_enabled};
+use log::{info, log_enabled, trace};
 use rayon::ThreadPoolBuilder;
 use strum::IntoEnumIterator;
 
@@ -135,6 +135,7 @@ fn check(cmd_args: CheckCmd) -> Result<()> {
     let ProjectRunData {
         irritations,
         num_files_scanned,
+        num_bytes_scanned,
     } = scan::scan_project(
         &ctx,
         &store,
@@ -145,12 +146,28 @@ fn check(cmd_args: CheckCmd) -> Result<()> {
     irritations
         .iter()
         .for_each(|irr| crate::warn!(custom=true; "{irr}"));
+
     if log_enabled!(log::Level::Info) {
         info!(
             "scanned {}",
             Plural::new(num_files_scanned, "file", "files"),
         );
     }
+    if log_enabled!(log::Level::Trace) {
+        let pretty_approx = |num| {
+            if num < 1_000 {
+                format!("{num}")
+            } else if num < 1_000_000 {
+                format!("{:.1}K", num as f64 / 1_000.0)
+            } else if num < 1_000_000_000 {
+                format!("{:.1}M", num as f64 / 1_000_000.0)
+            } else {
+                format!("{:.1}G", num as f64 / 1_000_000_000.0)
+            }
+        };
+        trace!("scanned {} bytes", pretty_approx(num_bytes_scanned),);
+    }
+
     let num_problems = irritations.len()
         + *logger::NUM_ERRS.lock().expect("failed to lock NUM_ERRS") as usize
         + *logger::NUM_WARNINGS

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -35,7 +35,8 @@ use crate::{
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct ProjectRunData {
     pub irritations: Vec<Irritation>,
-    pub num_files_scanned: usize,
+    pub num_files_scanned: u64,
+    pub num_bytes_scanned: u64,
 }
 
 pub fn scan_project(
@@ -124,6 +125,9 @@ pub fn scan_project(
             !max_problems.is_exceeded_by(prev_total_irritations)
         })
         .collect::<Result<_>>()?;
+
+    let num_files_scanned = run_data.len() as u64;
+    let num_bytes_scanned = run_data.iter().map(|rd| rd.num_bytes_scanned).sum();
     for rd in run_data {
         irritations.extend(rd.irritations);
     }
@@ -135,15 +139,18 @@ pub fn scan_project(
             irritations.truncate(max);
         }
     }
+
     Ok(ProjectRunData {
         irritations,
-        num_files_scanned: files.len(),
+        num_files_scanned,
+        num_bytes_scanned,
     })
 }
 
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct FileRunData {
     pub irritations: Vec<Irritation>,
+    pub num_bytes_scanned: u64,
 }
 
 pub struct VexFileOptions<'a> {
@@ -207,7 +214,10 @@ fn scan_file(file: &SourceFile, opts: VexFileOptions<'_>) -> Result<FileRunData>
         .all(|(l, _, _)| *l != language)
     {
         // The user did not request a scan of this type of file.
-        return Ok(FileRunData { irritations });
+        return Ok(FileRunData {
+            irritations,
+            num_bytes_scanned: 0,
+        });
     }
 
     let parsed_file = file.parse()?;
@@ -257,5 +267,9 @@ fn scan_file(file: &SourceFile, opts: VexFileOptions<'_>) -> Result<FileRunData>
                     Result::Ok(())
                 })
         })?;
-    Ok(FileRunData { irritations })
+    let num_bytes_scanned = parsed_file.content.len() as u64;
+    Ok(FileRunData {
+        irritations,
+        num_bytes_scanned,
+    })
 }

--- a/src/trigger.rs
+++ b/src/trigger.rs
@@ -159,10 +159,10 @@ mod test {
 
             let run_data = test.try_run().unwrap();
             assert_eq!(
-                1 + language_tests
+                language_tests
                     .iter()
-                    .map(|lt| lt.files.len())
-                    .sum::<usize>(),
+                    .map(|lt| lt.files.len() as u64)
+                    .sum::<u64>(),
                 run_data.num_files_scanned,
                 "wrong number of files scanned"
             );


### PR DESCRIPTION
This PR amends the number-of-files-scanned report message to take into account early exits for example due to the maximum number of problems being reached. Now, it shows the number of files scanned rather than the number which _would_ have been scanned.

This PR also adds reports the number of bytes scanned.
