### PR TITLE
Improve manifest section clarity

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -190,7 +190,7 @@ fn init(init_args: InitCmd) -> Result<()> {
         cause,
     })?)?;
     Context::init(cwd, init_args.force)?;
-    let queries_dir = Context::acquire()?.manifest.metadata.queries_dir;
+    let vexes_dir = Context::acquire()?.manifest.run.vexes_dir;
     success!(
         "{}",
         formatdoc!(
@@ -198,8 +198,8 @@ fn init(init_args: InitCmd) -> Result<()> {
                 vex initialised
                 now add style rules in ./{}/
                 for an example, open ./{}/{EXAMPLE_VEX_FILE}",
-            queries_dir.as_str(),
-            queries_dir.as_str(),
+            vexes_dir.as_str(),
+            vexes_dir.as_str(),
         )
     );
     Ok(())

--- a/src/source_file.rs
+++ b/src/source_file.rs
@@ -24,7 +24,7 @@ pub fn sources_in_dir(
     max_concurrent_files: MaxConcurrentFileLimit,
 ) -> Result<Vec<SourceFile>> {
     let ignores: Vec<_> = ctx
-        .metadata
+        .files
         .ignores
         .clone()
         .into_inner()
@@ -32,7 +32,7 @@ pub fn sources_in_dir(
         .map(|ignore| ignore.compile())
         .collect::<Result<_>>()?;
     let allows: Vec<_> = ctx
-        .metadata
+        .files
         .allows
         .clone()
         .into_iter()
@@ -326,6 +326,9 @@ mod test {
 
         let manifest_content: &str = indoc! {r#"
             [vex]
+            version = "1"
+
+            [files]
             ignore = [ "to-ignore", "to-allow" ]
             allow = [ "to-allow" ]
         "#};

--- a/src/vextest.rs
+++ b/src/vextest.rs
@@ -148,7 +148,10 @@ impl<'s> VexTest<'s> {
         let root_path = Utf8PathBuf::try_from(root_dir.path().to_path_buf()).unwrap();
 
         if !self.bare {
-            let manifest_content = self.manifest_content.as_deref().unwrap_or("[vex]");
+            let manifest_content = self
+                .manifest_content
+                .as_deref()
+                .unwrap_or("[vex]\nversion = '1'");
             File::create(root_path.join("vex.toml"))
                 .unwrap()
                 .write_all(manifest_content.as_bytes())


### PR DESCRIPTION
This PR separates out configuration into clearly-named and extensible sections. Initial user-testing suggests that the proposed structure is more intuitive than the last.

Below are two valid manifests.
The following one is a manifest with the most keys used:

```toml
[vex]
version = "1"
directory = "some-dir/"

[files]
ignore = ["vexes/", "target/"]
allow = ["vexes/check-me.star", "target/check-me.rs"]

[lints.active]
lint-id-1 = false
lint-id-2 = true

[languages.python]
use-for = ["*.star", "*.py2"]
```

The following is a manifest with the fewest keys used:

```toml
[vex]
version = "1"
```
