### PR TITLE
Add placeholder `Lsp` object

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -39,7 +39,7 @@ impl Context {
                 || manifest
                     .languages
                     .values()
-                    .any(|language_options| language_options.lsp_server.is_some());
+                    .any(|language_options| language_options.language_server.is_some());
             if !suppress_warning && lsp_features_used {
                 warn!("LSP features requested but current support is experimental (Set VEX_LSP=1 to suppress this warning)");
             }
@@ -368,7 +368,7 @@ impl Default for LanguagesConfig {
                 SupportedLanguage::Python,
                 LanguageOptions {
                     file_associations: vec![RawFilePattern::new("*.star".into())],
-                    lsp_server: None,
+                    language_server: None,
                 },
             )]
             .into_iter()
@@ -391,7 +391,7 @@ pub struct LanguageOptions {
     #[serde(rename = "use-for", default)]
     file_associations: Vec<RawFilePattern<String>>,
 
-    lsp_server: Option<String>,
+    language_server: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialise, Serialise, PartialEq)]
@@ -615,7 +615,7 @@ mod tests {
 
             [languages.python]
             use-for = ["*.star", "*.py2"]
-            lsp-server = "custom-language-server"
+            language-server = "custom-language-server"
         "#};
         let parsed_manifest: Manifest = toml_edit::de::from_str(manifest_content).unwrap();
 
@@ -640,7 +640,7 @@ mod tests {
         );
         assert_eq!(
             parsed_manifest.languages[&SupportedLanguage::Python]
-                .lsp_server
+                .language_server
                 .as_deref(),
             Some("custom-language-server")
         );

--- a/src/error.rs
+++ b/src/error.rs
@@ -73,6 +73,9 @@ pub enum Error {
     #[error(transparent)]
     Language(#[from] tree_sitter::LanguageError),
 
+    #[error("lsp disabled")]
+    LspDisabled,
+
     #[error("cannot find manifest, try running `vex init` in the project’s root")]
     ManifestNotFound,
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -73,9 +73,6 @@ pub enum Error {
     #[error(transparent)]
     Language(#[from] tree_sitter::LanguageError),
 
-    #[error("lsp disabled")]
-    LspDisabled,
-
     #[error("cannot find manifest, try running `vex init` in the project’s root")]
     ManifestNotFound,
 

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -54,6 +54,7 @@ pub fn scan_project(
     let file_queries_hint = store.file_queries_hint();
 
     let query_cache = QueryCache::with_capacity(project_queries_hint + file_queries_hint);
+    let lsp_enabled = ctx.manifest.run.lsp_enabled;
 
     let mut irritations = vec![];
     let frozen_heap = store.frozen_heap();
@@ -67,6 +68,7 @@ pub fn scan_project(
             query_cache: Some(&query_cache),
             warning_filter: Some(&warning_filter),
             ignore_markers: None,
+            lsp_enabled,
             print_handler: &PrintHandler::new(verbosity, event.kind().name()),
         };
         store.observers_for(event.kind()).observe(
@@ -108,6 +110,7 @@ pub fn scan_project(
             let opts = VexFileOptions {
                 store,
                 language,
+                lsp_enabled,
                 project_queries: &project_queries,
                 query_cache: &query_cache,
                 warning_filter: &warning_filter,
@@ -160,6 +163,7 @@ pub struct FileRunData {
 pub struct VexFileOptions<'a> {
     store: &'a VexingStore,
     language: SupportedLanguage,
+    lsp_enabled: bool,
     project_queries: &'a [(SupportedLanguage, Arc<Query>, Observer)],
     query_cache: &'a QueryCache,
     warning_filter: &'a WarningFilter,
@@ -170,6 +174,7 @@ fn scan_file(file: &SourceFile, opts: VexFileOptions<'_>) -> Result<FileRunData>
     let VexFileOptions {
         store,
         language,
+        lsp_enabled,
         project_queries,
         query_cache,
         warning_filter,
@@ -190,6 +195,7 @@ fn scan_file(file: &SourceFile, opts: VexFileOptions<'_>) -> Result<FileRunData>
             query_cache: Some(query_cache),
             warning_filter: Some(warning_filter),
             ignore_markers: None,
+            lsp_enabled,
             print_handler: &PrintHandler::new(verbosity, event.kind().name()),
         };
         store.observers_for(event.kind()).observe(
@@ -253,6 +259,7 @@ fn scan_file(file: &SourceFile, opts: VexFileOptions<'_>) -> Result<FileRunData>
                         query_cache: Some(query_cache),
                         warning_filter: Some(warning_filter),
                         ignore_markers: Some(&ignore_markers),
+                        lsp_enabled,
                         print_handler: &PrintHandler::new(verbosity, EventKind::Match.name()),
                     };
                     on_match.observe(&handler_module, event, observe_opts)?;

--- a/src/scriptlets.rs
+++ b/src/scriptlets.rs
@@ -4,6 +4,7 @@ pub mod event;
 pub mod extra_data;
 pub mod handler_module;
 pub mod intents;
+mod lsp;
 pub mod main_annotation;
 mod node;
 mod observers;

--- a/src/scriptlets/app_object.rs
+++ b/src/scriptlets/app_object.rs
@@ -107,12 +107,8 @@ impl AppObject {
                 ],
             )?;
 
-            let extra: &TempData<'_> = eval
-                .extra
-                .expect("internal error: Evaluator extra not set")
-                .downcast_ref()
-                .expect("internal erro: Evaluator extra has wrong type");
-            if !extra.lsp_enabled {
+            let temp_data = TempData::get_from(eval);
+            if !temp_data.lsp_enabled {
                 return Err(Error::LspDisabled.into());
             }
 

--- a/src/scriptlets/app_object.rs
+++ b/src/scriptlets/app_object.rs
@@ -97,25 +97,26 @@ impl AppObject {
             #[starlark(this)] _this: Value<'v>,
             #[starlark(require=pos)] language: &'v str,
             eval: &mut Evaluator<'v, '_>,
-        ) -> anyhow::Result<Lsp<'v>> {
+        ) -> anyhow::Result<Option<Lsp<'v>>> {
             AppObject::check_attr_available(
                 eval,
                 "vex.lsp_for",
                 &[
                     Action::Vexing(EventKind::OpenProject),
                     Action::Vexing(EventKind::OpenFile),
+                    Action::Vexing(EventKind::Match),
                 ],
             )?;
 
             let temp_data = TempData::get_from(eval);
             if !temp_data.lsp_enabled {
-                return Err(Error::LspDisabled.into());
+                return Ok(None);
             }
 
             let language = eval
                 .heap()
                 .alloc(language.parse::<SupportedLanguage>()?.to_string());
-            Ok(Lsp { language })
+            Ok(Some(Lsp { language }))
         }
 
         fn search<'v>(

--- a/src/scriptlets/extra_data.rs
+++ b/src/scriptlets/extra_data.rs
@@ -104,6 +104,7 @@ pub struct TempData<'v> {
     pub action: Action,
     pub query_cache: Option<&'v QueryCache>,
     pub ignore_markers: Option<&'v IgnoreMarkers>,
+    pub lsp_enabled: bool,
     pub warning_filter: Option<&'v WarningFilter>,
 }
 

--- a/src/scriptlets/lsp.rs
+++ b/src/scriptlets/lsp.rs
@@ -1,25 +1,49 @@
 use std::fmt::Display;
 
 use allocative::Allocative;
-use starlark::values::StarlarkValue;
-use starlark_derive::{starlark_value, NoSerialize, ProvidesStaticType};
+use dupe::Dupe;
+use starlark::values::{AllocValue, Heap, StarlarkValue, Value};
+use starlark_derive::{starlark_value, NoSerialize, ProvidesStaticType, Trace};
 
-#[derive(Debug, PartialEq, Eq, ProvidesStaticType, NoSerialize, Allocative)]
-pub struct Lsp;
-
-impl Lsp {
-    const NAME: &'static str = "lsp";
+#[derive(Debug, PartialEq, Eq, ProvidesStaticType, NoSerialize, Allocative, Trace)]
+pub struct Lsp<'v> {
+    pub language: Value<'v>,
 }
 
-impl Display for Lsp {
+impl Lsp<'_> {
+    const NAME: &'static str = "Lsp";
+    const LANGUAGE_ATTR_NAME: &'static str = "language";
+}
+
+impl Display for Lsp<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        Self::NAME.fmt(f)
+        write!(f, "{}", Self::NAME)
     }
 }
 
-starlark::starlark_simple_value!(Lsp);
 #[starlark_value(type = "Lsp")]
-impl<'v> StarlarkValue<'v> for Lsp {}
+impl<'v> StarlarkValue<'v> for Lsp<'v> {
+    fn dir_attr(&self) -> Vec<String> {
+        vec![Self::LANGUAGE_ATTR_NAME.to_owned()]
+    }
+
+    fn get_attr(&self, attr: &str, _heap: &'v Heap) -> Option<Value<'v>> {
+        match attr {
+            Self::LANGUAGE_ATTR_NAME => Some(self.language.dupe()),
+            _ => None,
+        }
+    }
+
+    fn has_attr(&self, attr: &str, _heap: &'v Heap) -> bool {
+        attr == Self::LANGUAGE_ATTR_NAME
+    }
+}
+
+impl<'v> AllocValue<'v> for Lsp<'v> {
+    fn alloc_value(self, heap: &'v Heap) -> Value<'v> {
+        heap.alloc_complex_no_freeze(self)
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -30,11 +54,16 @@ mod tests {
         syntax::{AstModule, Dialect},
     };
 
+    use crate::{supported_language::SupportedLanguage, vextest::VexTest};
+
     use super::*;
 
     #[test]
-    fn type_name() {
-        let lsp = Lsp;
+    fn properties() {
+        let module = Module::new();
+        let language = module.heap().alloc(SupportedLanguage::Rust.to_string());
+        let lsp = Lsp { language };
+        module.set("lsp", module.heap().alloc(lsp));
 
         let test_code = indoc! {r#"
             def test():
@@ -42,13 +71,42 @@ mod tests {
                 actual = type(lsp)
                 if actual != expected:
                     fail('expected type name %r but got %r' % (expected, actual))
+
+                if not hasattr(lsp, 'language'):
+                    fail("lsp has no 'language' field")
+                if 'language' not in dir(lsp):
+                    fail("lsp 'language' field improperly declared")
+                if lsp.language != 'rust':
+                    fail('incorrect lsp language: got %s' % lsp.language)
             test()
         "#};
         let ast = AstModule::parse("test.star", test_code.to_owned(), &Dialect::Standard).unwrap();
-        let globals = Globals::standard();
-        let module = Module::new();
-        module.set("lsp", module.heap().alloc(lsp));
+
         let mut eval = Evaluator::new(&module);
+        let globals = Globals::standard();
         eval.eval_module(ast, &globals).unwrap();
+    }
+
+    #[test]
+    fn availability() {
+        VexTest::new("enabled")
+            .with_manifest(indoc! {r#"
+                [vex]
+                version = "1"
+                enable-lsp = true
+            "#})
+            .with_scriptlet(
+                "vexes/test.star",
+                indoc! {"
+                    def init():
+                        vex.observe('open_project', on_open_project)
+
+                    def on_open_project(event):
+                        for language in ['rust', 'go', 'python']:
+                            if vex.lsp_for(language).language != language:
+                                fail('language server %r language server reported incorrect language' % language)
+                "},
+            )
+            .assert_irritation_free();
     }
 }

--- a/src/scriptlets/lsp.rs
+++ b/src/scriptlets/lsp.rs
@@ -108,5 +108,23 @@ mod tests {
                 "},
             )
             .assert_irritation_free();
+
+        VexTest::new("disabled")
+            .with_manifest(indoc! {r#"
+                [vex]
+                version = "1"
+                enable-lsp = false
+            "#})
+            .with_scriptlet(
+                "vexes/test.star",
+                indoc! {"
+                    def init():
+                        vex.observe('open_project', on_open_project)
+
+                    def on_open_project(event):
+                        vex.lsp_for('rust').language
+                "},
+            )
+            .returns_error("lsp disabled");
     }
 }

--- a/src/scriptlets/lsp.rs
+++ b/src/scriptlets/lsp.rs
@@ -1,0 +1,54 @@
+use std::fmt::Display;
+
+use allocative::Allocative;
+use starlark::values::StarlarkValue;
+use starlark_derive::{starlark_value, NoSerialize, ProvidesStaticType};
+
+#[derive(Debug, PartialEq, Eq, ProvidesStaticType, NoSerialize, Allocative)]
+pub struct Lsp;
+
+impl Lsp {
+    const NAME: &'static str = "lsp";
+}
+
+impl Display for Lsp {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Self::NAME.fmt(f)
+    }
+}
+
+starlark::starlark_simple_value!(Lsp);
+#[starlark_value(type = "Lsp")]
+impl<'v> StarlarkValue<'v> for Lsp {}
+
+#[cfg(test)]
+mod tests {
+    use indoc::indoc;
+    use starlark::{
+        environment::{Globals, Module},
+        eval::Evaluator,
+        syntax::{AstModule, Dialect},
+    };
+
+    use super::*;
+
+    #[test]
+    fn type_name() {
+        let lsp = Lsp;
+
+        let test_code = indoc! {r#"
+            def test():
+                expected = "Lsp"
+                actual = type(lsp)
+                if actual != expected:
+                    fail('expected type name %r but got %r' % (expected, actual))
+            test()
+        "#};
+        let ast = AstModule::parse("test.star", test_code.to_owned(), &Dialect::Standard).unwrap();
+        let globals = Globals::standard();
+        let module = Module::new();
+        module.set("lsp", module.heap().alloc(lsp));
+        let mut eval = Evaluator::new(&module);
+        eval.eval_module(ast, &globals).unwrap();
+    }
+}

--- a/src/scriptlets/lsp.rs
+++ b/src/scriptlets/lsp.rs
@@ -122,9 +122,11 @@ mod tests {
                         vex.observe('open_project', on_open_project)
 
                     def on_open_project(event):
-                        vex.lsp_for('rust').language
+                        lsp = vex.lsp_for('rust')
+                        if lsp != None:
+                            fail('unavailable lsp is not None')
                 "},
             )
-            .returns_error("lsp disabled");
+            .assert_irritation_free();
     }
 }

--- a/src/scriptlets/observers.rs
+++ b/src/scriptlets/observers.rs
@@ -132,6 +132,7 @@ pub struct ObserveOptions<'v> {
     pub action: Action,
     pub query_cache: Option<&'v QueryCache>,
     pub ignore_markers: Option<&'v IgnoreMarkers>,
+    pub lsp_enabled: bool,
     pub print_handler: &'v PrintHandler<'v>,
     pub warning_filter: Option<&'v WarningFilter>,
 }
@@ -147,6 +148,7 @@ impl Observable for Observer {
             action,
             query_cache,
             ignore_markers,
+            lsp_enabled,
             print_handler,
             warning_filter,
         } = opts;
@@ -154,6 +156,7 @@ impl Observable for Observer {
             action,
             query_cache,
             ignore_markers,
+            lsp_enabled,
             warning_filter,
         };
         let mut eval = Evaluator::new(handler_module);

--- a/src/scriptlets/scriptlet.rs
+++ b/src/scriptlets/scriptlet.rs
@@ -80,6 +80,7 @@ impl PreinitingScriptlet {
                     action: Action::Preiniting,
                     query_cache: None,
                     ignore_markers: None,
+                    lsp_enabled: false,
                     warning_filter: None,
                 };
                 let print_handler = PrintHandler::new(*verbosity, path.as_str());
@@ -357,6 +358,7 @@ impl InitingScriptlet {
                     action: Action::Initing,
                     query_cache: None,
                     ignore_markers: None,
+                    lsp_enabled: false,
                     warning_filter: None,
                 };
                 let print_handler = PrintHandler::new(*verbosity, path.as_str());

--- a/src/scriptlets/scriptlet.rs
+++ b/src/scriptlets/scriptlet.rs
@@ -549,6 +549,7 @@ mod tests {
             Unavailable,
             "vex.observe('open_file', lambda x: x)",
         );
+        test_preiniting_availability("vex.lsp_for", Unavailable, "vex.lsp_for('rust')");
         test_preiniting_availability(
             "vex.search",
             Unavailable,
@@ -604,6 +605,7 @@ mod tests {
             Unavailable,
             "vex.observe('open_file', lambda x: x)",
         );
+        test_vexing_open_availability("vex.lsp_for", Available, "vex.lsp_for('rust')");
         test_vexing_open_availability(
             "vex.search",
             Available,
@@ -656,6 +658,7 @@ mod tests {
             Unavailable,
             "vex.observe('open_file', lambda x: x)",
         );
+        test_vexing_match_availability("vex.lsp_for", Available, "vex.lsp_for('rust')");
         test_vexing_match_availability(
             "vex.search",
             Unavailable,

--- a/src/vextest.rs
+++ b/src/vextest.rs
@@ -18,6 +18,7 @@ use crate::{
         source::{ScriptSource, TestSource},
         InitOptions, PreinitOptions, PreinitingStore,
     },
+    test::RunTestOptions,
     verbosity::Verbosity,
     ProjectRunData,
 };
@@ -157,7 +158,10 @@ impl<'s> VexTest<'s> {
             fs::create_dir(ctx.vex_dir()).ok();
         }
         if self.fire_test_events {
-            crate::test::run_tests(&self.scriptlets)?;
+            crate::test::run_tests(RunTestOptions {
+                lsp_enabled: ctx.manifest.run.lsp_enabled,
+                script_sources: &self.scriptlets,
+            })?;
             Ok(ProjectRunData::default())
         } else {
             for (path, content) in &self.source_files {


### PR DESCRIPTION
This PR adds a new placeholder `Lsp` object which may be accessed via `vex.lsp_for(language)`. Further, it plumbs LSP enablement