### PR TITLE
Expose manifest args into scripts

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -367,7 +367,7 @@ impl ScriptArgsForId {
     }
 
     pub fn iter(&self) -> impl Iterator<Item = (&str, &ScriptArgValue)> {
-        self.0.iter().map(|(key, value)| (&key[..], value))
+        self.0.iter().map(|(key, value)| (key.as_str(), value))
     }
 }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -179,8 +179,9 @@ pub struct Manifest {
     #[serde(default)]
     pub files: FilesConfig,
 
+    #[serde(rename = "args")]
     #[serde(default)]
-    pub args: Args,
+    pub script_args: ScriptArgs,
 
     #[serde(default)]
     pub lints: LintsConfig,
@@ -342,30 +343,30 @@ pub struct FilesConfig {
 }
 
 #[derive(Clone, Debug, Default, Deserialise, Serialise, PartialEq)]
-pub struct Args(BTreeMap<Id, ArgsForId>);
+pub struct ScriptArgs(BTreeMap<Id, ScriptArgsForId>);
 
-impl Args {
-    pub fn get(&self, key: &Id) -> Option<&ArgsForId> {
+impl ScriptArgs {
+    pub fn get(&self, key: &Id) -> Option<&ScriptArgsForId> {
         self.0.get(key)
     }
 }
 
-impl Default for &Args {
+impl Default for &ScriptArgs {
     fn default() -> Self {
-        static DEFAULT_ARGS: Args = Args(BTreeMap::new());
+        static DEFAULT_ARGS: ScriptArgs = ScriptArgs(BTreeMap::new());
         &DEFAULT_ARGS
     }
 }
 
 #[derive(Clone, Debug, Deserialise, Serialise, PartialEq)]
-pub struct ArgsForId(BTreeMap<String, ArgValue>);
+pub struct ScriptArgsForId(BTreeMap<String, ScriptArgValue>);
 
-impl ArgsForId {
-    pub fn get(&self, key: &str) -> Option<&ArgValue> {
+impl ScriptArgsForId {
+    pub fn get(&self, key: &str) -> Option<&ScriptArgValue> {
         self.0.get(key)
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = (&str, &ArgValue)> {
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &ScriptArgValue)> {
         self.0.iter().map(|(key, value)| (&key[..], value))
     }
 }
@@ -373,16 +374,16 @@ impl ArgsForId {
 #[derive(Clone, Debug, Deserialise, Serialise, PartialEq)]
 #[serde(untagged)]
 #[serde(expecting = "invalid type: expecting a bool, int, float, string, sequence or table")]
-pub enum ArgValue {
+pub enum ScriptArgValue {
     Bool(bool),
     Int(i64),
     Float(f64),
     String(String),
-    Sequence(Vec<ArgValue>),
-    Table(BTreeMap<String, ArgValue>),
+    Sequence(Vec<ScriptArgValue>),
+    Table(BTreeMap<String, ScriptArgValue>),
 }
 
-impl ArgValue {
+impl ScriptArgValue {
     pub fn to_value_on<'v>(&self, heap: &'v Heap) -> Value<'v> {
         match self {
             Self::Bool(b) => Value::new_bool(*b),
@@ -679,7 +680,7 @@ mod tests {
 
     #[test]
     fn maximal_manifest() {
-        use ArgValue as AV;
+        use ScriptArgValue as SAV;
 
         let manifest_content = indoc! {r#"
             [vex]
@@ -717,19 +718,19 @@ mod tests {
             let hello_id = Id::try_from("hello".to_owned()).unwrap();
             assert_eq!(
                 parsed_manifest
-                    .args
+                    .script_args
                     .get(&hello_id)
                     .unwrap()
                     .get("world")
                     .unwrap(),
-                &AV::Sequence(vec![
-                    AV::Bool(true),
-                    AV::Int(123),
-                    AV::Float(123.4),
-                    AV::String("foo".into()),
-                    AV::Table(BTreeMap::from_iter([(
+                &SAV::Sequence(vec![
+                    SAV::Bool(true),
+                    SAV::Int(123),
+                    SAV::Float(123.4),
+                    SAV::String("foo".into()),
+                    SAV::Table(BTreeMap::from_iter([(
                         "bar".to_owned(),
-                        AV::Sequence(vec![AV::String("baz".into())]),
+                        SAV::Sequence(vec![SAV::String("baz".into())]),
                     )])),
                 ])
             );

--- a/src/id.rs
+++ b/src/id.rs
@@ -330,8 +330,8 @@ mod tests {
         let container = Container(BTreeMap::from_iter([(KEY.to_owned(), id.clone())]));
         let serialised = toml_edit::ser::to_string(&container).unwrap();
 
-        let parsed_container: Container = toml_edit::de::from_str(&serialised).unwrap();
-        assert_eq!(id, parsed_container.0[KEY]);
+        let Container(parsed_map) = toml_edit::de::from_str(&serialised).unwrap();
+        assert_eq!(id, parsed_map[KEY]);
 
         #[derive(Serialize, Deserialize)]
         struct Container(BTreeMap<String, Id>);

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,10 +117,11 @@ fn list(list_args: ListCmd) -> Result<()> {
 fn check(cmd_args: CheckCmd) -> Result<()> {
     let ctx = Context::acquire()?;
     let verbosity = logger::verbosity();
+    let args = &ctx.args;
 
     let store = {
-        let preinit_opts = PreinitOptions { verbosity };
-        let init_opts = InitOptions { verbosity };
+        let preinit_opts = PreinitOptions { args, verbosity };
+        let init_opts = InitOptions { args, verbosity };
         PreinitingStore::new(&source::sources_in_dir(&ctx.vex_dir())?)?
             .preinit(preinit_opts)?
             .init(init_opts)?

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,11 +117,17 @@ fn list(list_args: ListCmd) -> Result<()> {
 fn check(cmd_args: CheckCmd) -> Result<()> {
     let ctx = Context::acquire()?;
     let verbosity = logger::verbosity();
-    let args = &ctx.args;
+    let script_args = &ctx.script_args;
 
     let store = {
-        let preinit_opts = PreinitOptions { args, verbosity };
-        let init_opts = InitOptions { args, verbosity };
+        let preinit_opts = PreinitOptions {
+            script_args,
+            verbosity,
+        };
+        let init_opts = InitOptions {
+            script_args,
+            verbosity,
+        };
         PreinitingStore::new(&source::sources_in_dir(&ctx.vex_dir())?)?
             .preinit(preinit_opts)?
             .init(init_opts)?

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -14,7 +14,7 @@ use tree_sitter::QueryCursor;
 
 use crate::{
     cli::{MaxConcurrentFileLimit, MaxProblems},
-    context::Context,
+    context::{Args, Context},
     irritation::Irritation,
     query::Query,
     result::Result,
@@ -53,6 +53,7 @@ pub fn scan_project(
     let project_queries_hint = store.project_queries_hint();
     let file_queries_hint = store.file_queries_hint();
 
+    let args = &ctx.args;
     let query_cache = QueryCache::with_capacity(project_queries_hint + file_queries_hint);
     let lsp_enabled = ctx.manifest.run.lsp_enabled;
 
@@ -65,6 +66,7 @@ pub fn scan_project(
         let handler_module = HandlerModule::new();
         let observe_opts = ObserveOptions {
             action: Action::Vexing(event.kind()),
+            args,
             query_cache: Some(&query_cache),
             warning_filter: Some(&warning_filter),
             ignore_markers: None,
@@ -114,6 +116,7 @@ pub fn scan_project(
                 project_queries: &project_queries,
                 query_cache: &query_cache,
                 warning_filter: &warning_filter,
+                args: &args,
                 verbosity,
             };
             scan_file(file, opts)
@@ -167,6 +170,7 @@ pub struct VexFileOptions<'a> {
     project_queries: &'a [(SupportedLanguage, Arc<Query>, Observer)],
     query_cache: &'a QueryCache,
     warning_filter: &'a WarningFilter,
+    args: &'a Args,
     verbosity: Verbosity,
 }
 
@@ -178,6 +182,7 @@ fn scan_file(file: &SourceFile, opts: VexFileOptions<'_>) -> Result<FileRunData>
         project_queries,
         query_cache,
         warning_filter,
+        args,
         verbosity,
     } = opts;
 
@@ -192,6 +197,7 @@ fn scan_file(file: &SourceFile, opts: VexFileOptions<'_>) -> Result<FileRunData>
         let handler_module = HandlerModule::new();
         let observe_opts = ObserveOptions {
             action: Action::Vexing(event.kind()),
+            args,
             query_cache: Some(query_cache),
             warning_filter: Some(warning_filter),
             ignore_markers: None,
@@ -256,6 +262,7 @@ fn scan_file(file: &SourceFile, opts: VexFileOptions<'_>) -> Result<FileRunData>
                     };
                     let observe_opts = ObserveOptions {
                         action: Action::Vexing(EventKind::Match),
+                        args,
                         query_cache: Some(query_cache),
                         warning_filter: Some(warning_filter),
                         ignore_markers: Some(&ignore_markers),

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -14,7 +14,7 @@ use tree_sitter::QueryCursor;
 
 use crate::{
     cli::{MaxConcurrentFileLimit, MaxProblems},
-    context::{Args, Context},
+    context::{Context, ScriptArgs},
     irritation::Irritation,
     query::Query,
     result::Result,
@@ -53,7 +53,7 @@ pub fn scan_project(
     let project_queries_hint = store.project_queries_hint();
     let file_queries_hint = store.file_queries_hint();
 
-    let args = &ctx.args;
+    let script_args = &ctx.script_args;
     let query_cache = QueryCache::with_capacity(project_queries_hint + file_queries_hint);
     let lsp_enabled = ctx.manifest.run.lsp_enabled;
 
@@ -66,7 +66,7 @@ pub fn scan_project(
         let handler_module = HandlerModule::new();
         let observe_opts = ObserveOptions {
             action: Action::Vexing(event.kind()),
-            args,
+            script_args,
             query_cache: Some(&query_cache),
             warning_filter: Some(&warning_filter),
             ignore_markers: None,
@@ -116,7 +116,7 @@ pub fn scan_project(
                 project_queries: &project_queries,
                 query_cache: &query_cache,
                 warning_filter: &warning_filter,
-                args: &args,
+                script_args: &script_args,
                 verbosity,
             };
             scan_file(file, opts)
@@ -170,7 +170,7 @@ pub struct VexFileOptions<'a> {
     project_queries: &'a [(SupportedLanguage, Arc<Query>, Observer)],
     query_cache: &'a QueryCache,
     warning_filter: &'a WarningFilter,
-    args: &'a Args,
+    script_args: &'a ScriptArgs,
     verbosity: Verbosity,
 }
 
@@ -182,7 +182,7 @@ fn scan_file(file: &SourceFile, opts: VexFileOptions<'_>) -> Result<FileRunData>
         project_queries,
         query_cache,
         warning_filter,
-        args,
+        script_args,
         verbosity,
     } = opts;
 
@@ -197,7 +197,7 @@ fn scan_file(file: &SourceFile, opts: VexFileOptions<'_>) -> Result<FileRunData>
         let handler_module = HandlerModule::new();
         let observe_opts = ObserveOptions {
             action: Action::Vexing(event.kind()),
-            args,
+            script_args,
             query_cache: Some(query_cache),
             warning_filter: Some(warning_filter),
             ignore_markers: None,
@@ -262,7 +262,7 @@ fn scan_file(file: &SourceFile, opts: VexFileOptions<'_>) -> Result<FileRunData>
                     };
                     let observe_opts = ObserveOptions {
                         action: Action::Vexing(EventKind::Match),
-                        args,
+                        script_args,
                         query_cache: Some(query_cache),
                         warning_filter: Some(warning_filter),
                         ignore_markers: Some(&ignore_markers),

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -116,7 +116,7 @@ pub fn scan_project(
                 project_queries: &project_queries,
                 query_cache: &query_cache,
                 warning_filter: &warning_filter,
-                script_args: &script_args,
+                script_args,
                 verbosity,
             };
             scan_file(file, opts)

--- a/src/scriptlets/app_object.rs
+++ b/src/scriptlets/app_object.rs
@@ -8,15 +8,15 @@ use starlark::{
     eval::Evaluator,
     starlark_module,
     values::{
-        list::UnpackList, none::NoneType, NoSerialize, ProvidesStaticType, StarlarkValue,
-        StringValue, Value,
+        dict::AllocDict, list::UnpackList, none::NoneType, NoSerialize, ProvidesStaticType,
+        StarlarkValue, StringValue, Value,
     },
 };
 use starlark_derive::starlark_value;
 
 use crate::{
     error::Error,
-    id::{GroupId, LintId},
+    id::{GroupId, Id, LintId},
     irritation::IrritationRenderer,
     query::Query,
     result::Result,
@@ -91,6 +91,37 @@ impl AppObject {
                 }
             });
             Ok(active)
+        }
+
+        fn args_for<'v>(
+            #[starlark(this)] _this: Value<'v>,
+            #[starlark(require=pos)] id: &'v str,
+            eval: &mut Evaluator<'v, '_>,
+        ) -> anyhow::Result<Value<'v>> {
+            AppObject::check_attr_available(
+                eval,
+                "vex.args_for",
+                &[
+                    Action::Vexing(EventKind::OpenProject),
+                    Action::Vexing(EventKind::OpenFile),
+                    Action::Vexing(EventKind::Match),
+                ],
+            )?;
+
+            let id = Id::try_from(id.to_owned())?;
+
+            let temp_data = TempData::get_from(eval);
+            let args = temp_data.args;
+
+            let heap = eval.heap();
+            let args_for_id = match args.get(&id) {
+                Some(a) => a,
+                None => return Ok(heap.alloc(AllocDict::<[(Value<'_>, Value<'_>); 0]>([]))),
+            };
+            let args_dict = heap.alloc(AllocDict(
+                args_for_id.iter().map(|(k, v)| (k, v.to_value_on(heap))),
+            ));
+            Ok(args_dict)
         }
 
         fn lsp_for<'v>(
@@ -295,6 +326,7 @@ mod tests {
                         load('{check_path}', 'check')
                         expected_attrs = [
                             'active',
+                            'args_for',
                             'lsp_for',
                             'observe',
                             'scan',
@@ -646,5 +678,61 @@ mod tests {
             });
 
         assert_yaml_snapshot!(irritations);
+    }
+
+    #[test]
+    fn args_for() {
+        const ID: &str = "some-id";
+        VexTest::new("empty")
+            .with_manifest(indoc! {r#"
+                [vex]
+                version = "1"
+            "#})
+            .with_scriptlet(
+                "vexes/test.star",
+                formatdoc! {
+                    r"
+                        load('{check_path}', 'check')
+
+                        def init():
+                            vex.observe('open_project', on_open_project)
+
+                        def on_open_project(event):
+                            args = vex.args_for('{ID}')
+                            check['eq'](len(args), 0)
+
+                    ",
+                    check_path = VexTest::CHECK_STARLARK_PATH,
+                },
+            )
+            .assert_irritation_free();
+        VexTest::new("specified")
+            .with_manifest(formatdoc! {r#"
+                [vex]
+                version = "1"
+
+                [args]
+                {ID}.some-key = [true, {{x = [123]}}]
+            "#})
+            .with_scriptlet(
+                "vexes/test.star",
+                formatdoc! {
+                    r"
+                        load('{check_path}', 'check')
+
+                        def init():
+                            vex.observe('open_project', on_open_project)
+
+                        def on_open_project(event):
+                            args = vex.args_for('{ID}')
+                            check['eq'](len(args), 1)
+                            check['true']('some-key' in args)
+                            check['eq'](args['some-key'], [True, {{'x': [123]}}])
+
+                    ",
+                    check_path = VexTest::CHECK_STARLARK_PATH,
+                },
+            )
+            .assert_irritation_free();
     }
 }

--- a/src/scriptlets/app_object.rs
+++ b/src/scriptlets/app_object.rs
@@ -111,17 +111,19 @@ impl AppObject {
             let id = Id::try_from(id.to_owned())?;
 
             let temp_data = TempData::get_from(eval);
-            let args = temp_data.args;
+            let script_args = temp_data.script_args;
 
             let heap = eval.heap();
-            let args_for_id = match args.get(&id) {
+            let script_args_for_id = match script_args.get(&id) {
                 Some(a) => a,
                 None => return Ok(heap.alloc(AllocDict::<[(Value<'_>, Value<'_>); 0]>([]))),
             };
-            let args_dict = heap.alloc(AllocDict(
-                args_for_id.iter().map(|(k, v)| (k, v.to_value_on(heap))),
+            let ret = heap.alloc(AllocDict(
+                script_args_for_id
+                    .iter()
+                    .map(|(k, v)| (k, v.to_value_on(heap))),
             ));
-            Ok(args_dict)
+            Ok(ret)
         }
 
         fn lsp_for<'v>(

--- a/src/scriptlets/extra_data.rs
+++ b/src/scriptlets/extra_data.rs
@@ -8,7 +8,7 @@ use starlark::{
 use starlark_derive::{starlark_value, NoSerialize, Trace};
 
 use crate::{
-    context::Args,
+    context::ScriptArgs,
     ignore_markers::IgnoreMarkers,
     scriptlets::{
         action::Action,
@@ -103,7 +103,7 @@ impl<'v> AllocValue<'v> for RetainedData {
 #[derive(Debug, ProvidesStaticType)]
 pub struct TempData<'v> {
     pub action: Action,
-    pub args: &'v Args,
+    pub script_args: &'v ScriptArgs,
     pub query_cache: Option<&'v QueryCache>,
     pub ignore_markers: Option<&'v IgnoreMarkers>,
     pub lsp_enabled: bool,

--- a/src/scriptlets/extra_data.rs
+++ b/src/scriptlets/extra_data.rs
@@ -8,6 +8,7 @@ use starlark::{
 use starlark_derive::{starlark_value, NoSerialize, Trace};
 
 use crate::{
+    context::Args,
     ignore_markers::IgnoreMarkers,
     scriptlets::{
         action::Action,
@@ -102,6 +103,7 @@ impl<'v> AllocValue<'v> for RetainedData {
 #[derive(Debug, ProvidesStaticType)]
 pub struct TempData<'v> {
     pub action: Action,
+    pub args: &'v Args,
     pub query_cache: Option<&'v QueryCache>,
     pub ignore_markers: Option<&'v IgnoreMarkers>,
     pub lsp_enabled: bool,

--- a/src/scriptlets/observers.rs
+++ b/src/scriptlets/observers.rs
@@ -8,6 +8,7 @@ use starlark::{
 use starlark_derive::{starlark_value, NoSerialize, ProvidesStaticType, Trace};
 
 use crate::{
+    context::Args,
     ignore_markers::IgnoreMarkers,
     result::Result,
     scriptlets::{
@@ -130,6 +131,7 @@ pub trait Observable {
 #[derive(Clone, Debug, Dupe)]
 pub struct ObserveOptions<'v> {
     pub action: Action,
+    pub args: &'v Args,
     pub query_cache: Option<&'v QueryCache>,
     pub ignore_markers: Option<&'v IgnoreMarkers>,
     pub lsp_enabled: bool,
@@ -146,6 +148,7 @@ impl Observable for Observer {
     ) -> Result<()> {
         let ObserveOptions {
             action,
+            args,
             query_cache,
             ignore_markers,
             lsp_enabled,
@@ -154,6 +157,7 @@ impl Observable for Observer {
         } = opts;
         let temp_data = TempData {
             action,
+            args,
             query_cache,
             ignore_markers,
             lsp_enabled,

--- a/src/scriptlets/observers.rs
+++ b/src/scriptlets/observers.rs
@@ -8,7 +8,7 @@ use starlark::{
 use starlark_derive::{starlark_value, NoSerialize, ProvidesStaticType, Trace};
 
 use crate::{
-    context::Args,
+    context::ScriptArgs,
     ignore_markers::IgnoreMarkers,
     result::Result,
     scriptlets::{
@@ -131,7 +131,7 @@ pub trait Observable {
 #[derive(Clone, Debug, Dupe)]
 pub struct ObserveOptions<'v> {
     pub action: Action,
-    pub args: &'v Args,
+    pub script_args: &'v ScriptArgs,
     pub query_cache: Option<&'v QueryCache>,
     pub ignore_markers: Option<&'v IgnoreMarkers>,
     pub lsp_enabled: bool,
@@ -148,7 +148,7 @@ impl Observable for Observer {
     ) -> Result<()> {
         let ObserveOptions {
             action,
-            args,
+            script_args,
             query_cache,
             ignore_markers,
             lsp_enabled,
@@ -157,7 +157,7 @@ impl Observable for Observer {
         } = opts;
         let temp_data = TempData {
             action,
-            args,
+            script_args,
             query_cache,
             ignore_markers,
             lsp_enabled,

--- a/src/scriptlets/scriptlet.rs
+++ b/src/scriptlets/scriptlet.rs
@@ -69,7 +69,10 @@ impl PreinitingScriptlet {
         frozen_heap: &FrozenHeap,
     ) -> Result<InitingScriptlet> {
         let Self { path, ast, loads } = self;
-        let PreinitOptions { args, verbosity } = opts;
+        let PreinitOptions {
+            script_args,
+            verbosity,
+        } = opts;
 
         let preinited_module = {
             let preinited_module = Module::new();
@@ -78,7 +81,7 @@ impl PreinitingScriptlet {
             {
                 let temp_data = TempData {
                     action: Action::Preiniting,
-                    args,
+                    script_args,
                     query_cache: None,
                     ignore_markers: None,
                     lsp_enabled: false,
@@ -346,7 +349,10 @@ impl InitingScriptlet {
             path,
             preinited_module,
         } = self;
-        let InitOptions { args, verbosity } = opts;
+        let InitOptions {
+            script_args,
+            verbosity,
+        } = opts;
 
         let Some(init) = preinited_module.get_option("init")? else {
             return Ok(ObserverData::empty());
@@ -357,7 +363,7 @@ impl InitingScriptlet {
             {
                 let temp_data = TempData {
                     action: Action::Initing,
-                    args: &args,
+                    script_args: &script_args,
                     query_cache: None,
                     ignore_markers: None,
                     lsp_enabled: false,

--- a/src/scriptlets/scriptlet.rs
+++ b/src/scriptlets/scriptlet.rs
@@ -69,7 +69,7 @@ impl PreinitingScriptlet {
         frozen_heap: &FrozenHeap,
     ) -> Result<InitingScriptlet> {
         let Self { path, ast, loads } = self;
-        let PreinitOptions { verbosity } = opts;
+        let PreinitOptions { args, verbosity } = opts;
 
         let preinited_module = {
             let preinited_module = Module::new();
@@ -78,6 +78,7 @@ impl PreinitingScriptlet {
             {
                 let temp_data = TempData {
                     action: Action::Preiniting,
+                    args,
                     query_cache: None,
                     ignore_markers: None,
                     lsp_enabled: false,
@@ -345,7 +346,7 @@ impl InitingScriptlet {
             path,
             preinited_module,
         } = self;
-        let InitOptions { verbosity } = opts;
+        let InitOptions { args, verbosity } = opts;
 
         let Some(init) = preinited_module.get_option("init")? else {
             return Ok(ObserverData::empty());
@@ -356,6 +357,7 @@ impl InitingScriptlet {
             {
                 let temp_data = TempData {
                     action: Action::Initing,
+                    args: &args,
                     query_cache: None,
                     ignore_markers: None,
                     lsp_enabled: false,

--- a/src/scriptlets/scriptlet.rs
+++ b/src/scriptlets/scriptlet.rs
@@ -363,7 +363,7 @@ impl InitingScriptlet {
             {
                 let temp_data = TempData {
                     action: Action::Initing,
-                    script_args: &script_args,
+                    script_args,
                     query_cache: None,
                     ignore_markers: None,
                     lsp_enabled: false,

--- a/src/scriptlets/store.rs
+++ b/src/scriptlets/store.rs
@@ -9,7 +9,7 @@ use log::{info, log_enabled};
 use starlark::values::FrozenHeap;
 
 use crate::{
-    context::Args,
+    context::ScriptArgs,
     error::Error,
     result::Result,
     scriptlets::{
@@ -208,7 +208,7 @@ impl PreinitingStore {
 
 #[derive(Debug, Default)]
 pub struct PreinitOptions<'args> {
-    pub args: &'args Args,
+    pub script_args: &'args ScriptArgs,
     pub verbosity: Verbosity,
 }
 
@@ -267,7 +267,7 @@ impl InitingStore {
 
 #[derive(Debug, Default)]
 pub struct InitOptions<'args> {
-    pub args: &'args Args,
+    pub script_args: &'args ScriptArgs,
     pub verbosity: Verbosity,
 }
 

--- a/src/scriptlets/store.rs
+++ b/src/scriptlets/store.rs
@@ -9,6 +9,7 @@ use log::{info, log_enabled};
 use starlark::values::FrozenHeap;
 
 use crate::{
+    context::Args,
     error::Error,
     result::Result,
     scriptlets::{
@@ -46,7 +47,7 @@ impl PreinitingStore {
         Ok(Self { store })
     }
 
-    pub fn preinit(mut self, opts: PreinitOptions) -> Result<InitingStore> {
+    pub fn preinit(mut self, opts: PreinitOptions<'_>) -> Result<InitingStore> {
         self.store.sort_by(|sc1, sc2| sc1.path.cmp(&sc2.path));
         self.topographic_sort()?;
         let Self { store } = self;
@@ -206,7 +207,8 @@ impl PreinitingStore {
 }
 
 #[derive(Debug, Default)]
-pub struct PreinitOptions {
+pub struct PreinitOptions<'args> {
+    pub args: &'args Args,
     pub verbosity: Verbosity,
 }
 
@@ -242,7 +244,7 @@ pub struct InitingStore {
 }
 
 impl InitingStore {
-    pub fn init(self, opts: InitOptions) -> Result<VexingStore> {
+    pub fn init(self, opts: InitOptions<'_>) -> Result<VexingStore> {
         let Self { store, frozen_heap } = self;
         let num_scripts = store.len();
 
@@ -264,7 +266,8 @@ impl InitingStore {
 }
 
 #[derive(Debug, Default)]
-pub struct InitOptions {
+pub struct InitOptions<'args> {
+    pub args: &'args Args,
     pub verbosity: Verbosity,
 }
 

--- a/src/vextest.rs
+++ b/src/vextest.rs
@@ -154,14 +154,14 @@ impl<'s> VexTest<'s> {
         }
 
         let ctx = Context::acquire_in(&root_path).unwrap();
-        let args = &ctx.args;
+        let script_args = &ctx.script_args;
         if !self.bare {
             fs::create_dir(ctx.vex_dir()).ok();
         }
         if self.fire_test_events {
             crate::test::run_tests(RunTestOptions {
                 lsp_enabled: ctx.manifest.run.lsp_enabled,
-                args,
+                script_args,
                 script_sources: &self.scriptlets,
             })?;
             Ok(ProjectRunData::default())
@@ -178,8 +178,14 @@ impl<'s> VexTest<'s> {
             let warning_filter = crate::try_make_warning_filter(&ctx.manifest)?;
 
             let verbosity = Verbosity::default();
-            let preinit_opts = PreinitOptions { args, verbosity };
-            let init_opts = InitOptions { args, verbosity };
+            let preinit_opts = PreinitOptions {
+                script_args,
+                verbosity,
+            };
+            let init_opts = InitOptions {
+                script_args,
+                verbosity,
+            };
             let store = PreinitingStore::new(&self.scriptlets)?
                 .preinit(preinit_opts)?
                 .init(init_opts)?;

--- a/src/vextest.rs
+++ b/src/vextest.rs
@@ -154,12 +154,14 @@ impl<'s> VexTest<'s> {
         }
 
         let ctx = Context::acquire_in(&root_path).unwrap();
+        let args = &ctx.args;
         if !self.bare {
             fs::create_dir(ctx.vex_dir()).ok();
         }
         if self.fire_test_events {
             crate::test::run_tests(RunTestOptions {
                 lsp_enabled: ctx.manifest.run.lsp_enabled,
+                args,
                 script_sources: &self.scriptlets,
             })?;
             Ok(ProjectRunData::default())
@@ -176,8 +178,8 @@ impl<'s> VexTest<'s> {
             let warning_filter = crate::try_make_warning_filter(&ctx.manifest)?;
 
             let verbosity = Verbosity::default();
-            let preinit_opts = PreinitOptions { verbosity };
-            let init_opts = InitOptions { verbosity };
+            let preinit_opts = PreinitOptions { args, verbosity };
+            let init_opts = InitOptions { args, verbosity };
             let store = PreinitingStore::new(&self.scriptlets)?
                 .preinit(preinit_opts)?
                 .init(init_opts)?;


### PR DESCRIPTION
This PR adds a new method to the app object to allow access to manifest args. The intended usage is as follows.

Assume the following manifest:

```toml
[vex]
version = "1"

[args]
suspicious-vars.forbidden-names = [ 'for', 'gods', 'sake', 'open', 'the', 'silo', 'door' ]
```

The key `forbidden-names` with value `[ 'for', 'gods', 'sake', ... ]` will be exposed under the namespace `suspicious-vars`. This namespace should correspond to some lint or group ID.

```python
ID = 'suspicious-vars'

def init():
    vex.observe('open_project', on_open_project)

def on_open_project(event):
    vex.search(..., on_match)

def on_match(event):
    name = event.captures['name']

    args = vex.args_for(ID)
    forbidden_names = args['forbidden-names']
    if name not in forbidden_names:
        return
    vex.warn(ID, ...)
```
