### PR TITLE
Inherit manifest args in tests

### DIFF
--- a/src/scriptlets/app_object.rs
+++ b/src/scriptlets/app_object.rs
@@ -106,6 +106,8 @@ impl AppObject {
                     Action::Vexing(EventKind::OpenProject),
                     Action::Vexing(EventKind::OpenFile),
                     Action::Vexing(EventKind::Match),
+                    Action::Vexing(EventKind::PreTestRun),
+                    Action::Vexing(EventKind::PostTestRun),
                 ],
             )?;
 


### PR DESCRIPTION
This PR makes `vex.args_for` work in tests. This will allow `vex test` to be more realistic to a particular user's setup. This allows a passing `vex test` to be a stronger indication of a functional `vex check`
