### PR TITLE
Load custom tree-sitter parsers from disk

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "test-data/tree-sitter-lua"]
+	path = test-data/tree-sitter-lua
+	url = git@github.com:tree-sitter-grammars/tree-sitter-lua

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ checksum = "fe233a377643e0fc1a56421d7c90acdec45c291b30345eb9f08e8d0ddce5a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -133,9 +133,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.86"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "ascii-canvas"
@@ -208,9 +208,12 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.99"
+version = "1.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c51067fd44124faa7f870b4b1c969379ad32b2ba805aa959430ceaa384f695"
+checksum = "a012a0df96dd6d06ba9a1b29d6402d1a5d77c6befd2566afdc26e10603dc93d7"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -250,7 +253,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -391,7 +394,7 @@ checksum = "d150dea618e920167e5973d70ae6ece4385b7164e0d799fe7c122dd0a5d912ad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -404,7 +407,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.66",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -414,6 +417,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -421,6 +433,18 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -461,7 +485,7 @@ checksum = "3e7d0f888ea556a80f971cda6c897ce90ae0e7673fc1602eb2e9b86734e68768"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -508,12 +532,12 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -528,9 +552,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.1.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fd-lock"
@@ -562,6 +586,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs4"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7e180ac76c23b45e767bd7ae9579bc0bb458618c4bc71835926e098e61d15f8"
+dependencies = [
+ "rustix",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -746,15 +780,15 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libloading"
@@ -763,7 +797,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -925,6 +959,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "owo-colors"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -953,7 +993,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -961,6 +1001,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "path-slash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
 
 [[package]]
 name = "percent-encoding"
@@ -1005,9 +1051,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.85"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
@@ -1073,9 +1119,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.5"
+version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1117,15 +1163,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "0.38.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
 dependencies = [
  "bitflags 2.5.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1228,31 +1274,33 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.203"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.203"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.95",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.117"
+version = "1.0.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+checksum = "d00f4175c42ee48b15416f6193a959ba3a0d67fc699a0db9ad12df9f83991c7d"
 dependencies = [
+ "indexmap",
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
@@ -1265,7 +1313,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -1276,6 +1324,12 @@ checksum = "79e674e01f999af37c49f70a6ede167a8a60b2503e56c5599532a65baa5969a0"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "similar"
@@ -1343,7 +1397,7 @@ dependencies = [
  "dupe",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -1440,7 +1494,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.66",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -1466,9 +1520,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.66"
+version = "2.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
+checksum = "46f71c0377baf4ef1cc3e3402ded576dccc315800fbc62dfc7fe04b009773b4a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1477,14 +1531,16 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.10.1"
+version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "getrandom",
+ "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1525,22 +1581,22 @@ checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -1591,41 +1647,96 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.21.0"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705bf7c0958d0171dd7d3a6542f2f4f21d87ed5f1dc8db52919d3a6bed9a359a"
+checksum = "0203df02a3b6dd63575cc1d6e609edc2181c9a11867a271b25cfd2abff3ec5ca"
 dependencies = [
  "cc",
  "regex",
+ "regex-syntax 0.8.4",
+ "tree-sitter-language",
 ]
 
 [[package]]
 name = "tree-sitter-go"
-version = "0.21.0"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cb318be5ccf75f44e054acf6898a5c95d59b53443eed578e16be0cd7ec037f"
+checksum = "b13d476345220dbe600147dd444165c5791bf85ef53e28acbedd46112ee18431"
 dependencies = [
  "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-highlight"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "380a7706376fa6c52ba7bf71d1e7a93856ee8ab08a7680631dfa664fdd237d66"
+dependencies = [
+ "lazy_static",
+ "regex",
+ "thiserror",
  "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-language"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c199356c799a8945965bb5f2c55b2ad9d9aa7c4b4f6e587fe9dea0bc715e5f9c"
+
+[[package]]
+name = "tree-sitter-loader"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae207d06263c49495fe04e41c801e884dfec53e6a487ec6fc51c15e84042e582"
+dependencies = [
+ "anyhow",
+ "cc",
+ "dirs",
+ "fs4",
+ "indoc",
+ "libloading",
+ "once_cell",
+ "path-slash",
+ "regex",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tree-sitter",
+ "tree-sitter-highlight",
+ "tree-sitter-tags",
 ]
 
 [[package]]
 name = "tree-sitter-python"
-version = "0.21.0"
+version = "0.23.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4066c6cf678f962f8c2c4561f205945c84834cce73d981e71392624fdc390a9"
+checksum = "3d065aaa27f3aaceaf60c1f0e0ac09e1cb9eb8ed28e7bcdaa52129cffc7f4b04"
 dependencies = [
  "cc",
- "tree-sitter",
+ "tree-sitter-language",
 ]
 
 [[package]]
 name = "tree-sitter-rust"
-version = "0.21.2"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "277690f420bf90741dea984f3da038ace46c4fe6047cba57a66822226cde1c93"
+checksum = "a4d64d449ca63e683c562c7743946a646671ca23947b9c925c0cfbe65051a4af"
 dependencies = [
  "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-tags"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3badf626aa7bbe52972da001303088fddf1fee6903084fd83ee24f5ac7104f01"
+dependencies = [
+ "memchr",
+ "regex",
+ "thiserror",
  "tree-sitter",
 ]
 
@@ -1723,7 +1834,6 @@ dependencies = [
  "insta",
  "joinery",
  "lazy_static",
- "libloading",
  "log",
  "num-traits",
  "owo-colors",
@@ -1743,6 +1853,7 @@ dependencies = [
  "toml_edit",
  "tree-sitter",
  "tree-sitter-go",
+ "tree-sitter-loader",
  "tree-sitter-python",
  "tree-sitter-rust",
  "uniquote",
@@ -1787,7 +1898,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1811,7 +1922,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1831,18 +1951,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.5",
- "windows_aarch64_msvc 0.52.5",
- "windows_i686_gnu 0.52.5",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.5",
- "windows_x86_64_gnu 0.52.5",
- "windows_x86_64_gnullvm 0.52.5",
- "windows_x86_64_msvc 0.52.5",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -1853,9 +1973,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1865,9 +1985,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1877,15 +1997,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1895,9 +2015,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1907,9 +2027,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1919,9 +2039,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1931,9 +2051,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -1967,5 +2087,5 @@ checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.95",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -757,6 +757,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
+name = "libloading"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+dependencies = [
+ "cfg-if",
+ "windows-targets 0.52.5",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1713,6 +1723,7 @@ dependencies = [
  "insta",
  "joinery",
  "lazy_static",
+ "libloading",
  "log",
  "num-traits",
  "owo-colors",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ textwrap = { version = "0.16.1", default-features = false }
 walkdir = "2"
 rayon = "1.10.0"
 bumpalo = "3.16.0"
+libloading = "0.8.6"
 
 [dev-dependencies]
 insta = { version = "1.36.1", features = ["yaml"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,16 +40,16 @@ strum = { version = "0.25.0", features = ["derive"] }
 tempfile = "3.9.0"
 thiserror = "1.0.51"
 toml_edit = { version = "0.21.0", features = ["serde"] }
-tree-sitter = "0.21.0"
-tree-sitter-go = "0.21"
-tree-sitter-python = "0.21"
-tree-sitter-rust = "0.21"
+tree-sitter = "0.23"
+tree-sitter-go = "0.23"
+tree-sitter-python = "0.23"
+tree-sitter-rust = "0.23"
 uniquote = "4.0.0"
 textwrap = { version = "0.16.1", default-features = false }
 walkdir = "2"
 rayon = "1.10.0"
 bumpalo = "3.16.0"
-libloading = "0.8.6"
+tree-sitter-loader = "0.23"
 
 [dev-dependencies]
 insta = { version = "1.36.1", features = ["yaml"] }

--- a/src/context.rs
+++ b/src/context.rs
@@ -706,11 +706,12 @@ impl LanguageData {
 
         let loader = Loader::new()?;
         let src_path = parser_dir.join("src");
+        let compile_config = CompileConfig {
+            name: language.name().to_owned(),
+            ..CompileConfig::new(src_path.as_std_path(), None, None)
+        };
         loader
-            .load_language_at_path_with_name(CompileConfig {
-                name: language.name().to_owned(),
-                ..CompileConfig::new(src_path.as_std_path(), None, None)
-            })
+            .load_language_at_path_with_name(compile_config)
             .map_err(Error::from)
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -186,7 +186,7 @@ impl From<starlark::Error> for Error {
 
 #[derive(Debug, thiserror::Error)]
 pub enum ExternalLanguageError {
-    #[error("manifest does not define parser-dir")]
+    #[error("manifest does not define `parser-dir`")]
     MissingParserDir,
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -183,7 +183,7 @@ impl From<starlark::Error> for Error {
 
 #[derive(Debug, thiserror::Error)]
 pub enum ExternalLanguageError {
-    #[error("manifest does not define `parser-dir`")]
+    #[error("manifest language info missing `parser-dir` field")]
     MissingParserDir,
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -85,9 +85,6 @@ pub enum Error {
     #[error(transparent)]
     Language(#[from] tree_sitter::LanguageError),
 
-    #[error(transparent)]
-    LibLoading(#[from] libloading::Error),
-
     #[error("cannot find manifest, try running `vex init` in the project’s root")]
     ManifestNotFound,
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,6 +35,12 @@ pub enum Error {
     #[error("query is empty")]
     EmptyQuery,
 
+    #[error("cannot load language {language}: {cause}")]
+    ExternalLanguage {
+        language: Language,
+        cause: ExternalLanguageError,
+    },
+
     #[error(transparent)]
     Fmt(#[from] fmt::Error),
 
@@ -78,6 +84,9 @@ pub enum Error {
 
     #[error(transparent)]
     Language(#[from] tree_sitter::LanguageError),
+
+    #[error(transparent)]
+    LibLoading(#[from] libloading::Error),
 
     #[error("cannot find manifest, try running `vex init` in the project’s root")]
     ManifestNotFound,
@@ -173,6 +182,12 @@ impl From<starlark::Error> for Error {
     fn from(err: starlark::Error) -> Self {
         err.into_anyhow().into()
     }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ExternalLanguageError {
+    #[error("manifest does not define parser-dir")]
+    MissingParserDir,
 }
 
 #[derive(Debug, Display)]

--- a/src/language.rs
+++ b/src/language.rs
@@ -83,10 +83,10 @@ mod tests {
 
     #[test]
     fn is_builtin() {
-        Assert::language(Language::Go).is_builtin();
-        Assert::language(Language::Python).is_builtin();
-        Assert::language(Language::Rust).is_builtin();
-        Assert::language(Language::External(Arc::from("lua"))).is_not_builtin();
+        Assert::language(Language::Go).considered_builtin();
+        Assert::language(Language::Python).considered_builtin();
+        Assert::language(Language::Rust).considered_builtin();
+        Assert::language(Language::External(Arc::from("lua"))).considered_not_builtin();
 
         // test types.
         struct Assert {
@@ -98,11 +98,11 @@ mod tests {
                 Self { language }
             }
 
-            pub fn is_builtin(self) {
+            pub fn considered_builtin(self) {
                 assert!(self.language.is_builtin());
             }
 
-            pub fn is_not_builtin(self) {
+            pub fn considered_not_builtin(self) {
                 assert!(!self.language.is_builtin());
             }
         }

--- a/src/language.rs
+++ b/src/language.rs
@@ -27,6 +27,10 @@ impl Language {
             Self::External(l) => l,
         }
     }
+
+    pub fn is_builtin(&self) -> bool {
+        !matches!(self, Self::External(_))
+    }
 }
 
 impl FromStr for Language {
@@ -75,6 +79,33 @@ mod tests {
             assert_eq!(lang, lang.name().parse()?);
         }
         Ok(())
+    }
+
+    #[test]
+    fn is_builtin() {
+        Assert::language(Language::Go).is_builtin();
+        Assert::language(Language::Python).is_builtin();
+        Assert::language(Language::Rust).is_builtin();
+        Assert::language(Language::External(Arc::from("lua"))).is_not_builtin();
+
+        // test types.
+        struct Assert {
+            language: Language,
+        }
+
+        impl Assert {
+            pub fn language(language: Language) -> Self {
+                Self { language }
+            }
+
+            pub fn is_builtin(self) {
+                assert!(self.language.is_builtin());
+            }
+
+            pub fn is_not_builtin(self) {
+                assert!(!self.language.is_builtin());
+            }
+        }
     }
 
     #[test]

--- a/src/scriptlets/query_captures.rs
+++ b/src/scriptlets/query_captures.rs
@@ -207,7 +207,7 @@ mod tests {
     use camino::Utf8Path;
     use indoc::{formatdoc, indoc};
     use starlark::values::Heap;
-    use tree_sitter::{Parser, Query, QueryCursor, Language as TSLanguage};
+    use tree_sitter::{Language as TSLanguage, Parser, Query, QueryCursor};
 
     use crate::{
         context::{Context, Manifest},

--- a/src/scriptlets/query_captures.rs
+++ b/src/scriptlets/query_captures.rs
@@ -207,7 +207,7 @@ mod tests {
     use camino::Utf8Path;
     use indoc::{formatdoc, indoc};
     use starlark::values::Heap;
-    use tree_sitter::{Parser, Query, QueryCursor};
+    use tree_sitter::{Parser, Query, QueryCursor, Language as TSLanguage};
 
     use crate::{
         context::{Context, Manifest},
@@ -606,7 +606,7 @@ mod tests {
         )
         .unwrap();
 
-        let language = tree_sitter_rust::language();
+        let language = TSLanguage::from(tree_sitter_rust::LANGUAGE);
         let query_source = indoc! {r"
             (binary_expression) @absent_singleton ; zero-quantified
             (trait_item)+ @absent_list            ; one-or-more, unused
@@ -698,7 +698,7 @@ mod tests {
         )
         .unwrap();
 
-        let language = tree_sitter_rust::language();
+        let language = TSLanguage::from(tree_sitter_rust::LANGUAGE);
         let query_source = indoc! {r"
             (line_comment)+ @duplicated_pattern_name
             (let_declaration) @duplicated_pattern_name
@@ -770,7 +770,7 @@ mod tests {
         )
         .unwrap();
 
-        let language = tree_sitter_rust::language();
+        let language = TSLanguage::from(tree_sitter_rust::LANGUAGE);
         let query_source = indoc! {r"
             (
                 (line_comment)+ @duplicated_capture_name

--- a/src/trigger.rs
+++ b/src/trigger.rs
@@ -179,26 +179,29 @@ mod tests {
     }
 
     #[test]
-    fn unsupported_language() {
-        // VexTest::new("unsupported-language")
-        //     .with_scriptlet(
-        //         "vexes/test.star",
-        //         indoc! {r#"
-        //             def init():
-        //                 vex.observe('open_project', on_open_project)
-        //
-        //             def on_open_project(event):
-        //                 vex.search(
-        //                     'brainfuck',
-        //                     '(binary_expression)',
-        //                     on_match,
-        //                 )
-        //
-        //             def on_match(event):
-        //                 pass
-        //         "#},
-        //     )
-        //     .returns_error("cannot parse brainfuck")
+    fn undefined_language() {
+        // NOTE: 'undefined' here refers to the fact that no parser for brainfuck has been provided
+        // in this test. This is independent of a user using their own brainfuck parser---they are
+        // still free to do this. They are also still free to seek help.
+        VexTest::new("undefined-language")
+            .with_scriptlet(
+                "vexes/test.star",
+                indoc! {r#"
+                    def init():
+                        vex.observe('open_project', on_open_project)
+
+                    def on_open_project(event):
+                        vex.search(
+                            'brainfuck',
+                            '(binary_expression)',
+                            on_match,
+                        )
+
+                    def on_match(event):
+                        pass
+                "#},
+            )
+            .returns_error("cannot load language brainfuck")
     }
 
     #[test]

--- a/src/trigger.rs
+++ b/src/trigger.rs
@@ -180,25 +180,25 @@ mod tests {
 
     #[test]
     fn unsupported_language() {
-        VexTest::new("unsupported-language")
-            .with_scriptlet(
-                "vexes/test.star",
-                indoc! {r#"
-                    def init():
-                        vex.observe('open_project', on_open_project)
-
-                    def on_open_project(event):
-                        vex.search(
-                            'brainfuck',
-                            '(binary_expression)',
-                            on_match,
-                        )
-
-                    def on_match(event):
-                        pass
-                "#},
-            )
-            .returns_error("cannot parse brainfuck")
+        // VexTest::new("unsupported-language")
+        //     .with_scriptlet(
+        //         "vexes/test.star",
+        //         indoc! {r#"
+        //             def init():
+        //                 vex.observe('open_project', on_open_project)
+        //
+        //             def on_open_project(event):
+        //                 vex.search(
+        //                     'brainfuck',
+        //                     '(binary_expression)',
+        //                     on_match,
+        //                 )
+        //
+        //             def on_match(event):
+        //                 pass
+        //         "#},
+        //     )
+        //     .returns_error("cannot parse brainfuck")
     }
 
     #[test]

--- a/src/vextest.rs
+++ b/src/vextest.rs
@@ -1,7 +1,3 @@
-#[cfg(target_os = "linux")]
-use std::os::unix;
-#[cfg(target_os = "windows")]
-use std::os::windows;
 use std::{
     borrow::Cow,
     collections::BTreeMap,
@@ -9,6 +5,11 @@ use std::{
     fs::{self, File},
     io::Write,
 };
+
+#[cfg(unix)]
+use std::os::unix;
+#[cfg(windows)]
+use std::os::windows;
 
 use camino::{Utf8Component, Utf8PathBuf};
 use indoc::indoc;
@@ -188,18 +189,20 @@ impl<'s> VexTest<'s> {
                 fs::create_dir_all(parent).unwrap();
             }
 
-            #[cfg(target_os = "linux")]
+            #[cfg(unix)]
             {
                 unix::fs::symlink(parser_dir, link_file).unwrap();
                 continue;
             }
-            #[cfg(target_os = "windows")]
+            #[cfg(windows)]
             {
                 windows::fs::symlink_dir(parser_dir, link_file).unwrap();
                 continue;
             }
             #[allow(unreachable_code)]
             {
+                let _ = parser_dir;
+                let _ = link_file;
                 panic!("target OS not supported: {}", env::consts::OS);
             }
         }


### PR DESCRIPTION
This PR adds parser-loading via `tree-sitter-loader`. The `tree-sitter` and `tree-sitter-*` dependencies required a version bump to allow use of a newer version of`tree-sitter-loader` which enabled loading specific parsers by path.

Note: this PR does _not_ sandbox the imported parser, linking it into the process from a `*.so`/`*.dll` file stored on disk, likely from somewhere under the user's home directory. Therefore, these changes are _not_ compatible with snaps. This will be fixed in another PR in the (hopefully near) future which will use WASM to avoid linking untrusted binaries, thus fixing this
