### PR TITLE
Support ignore queries for external languages

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -1023,10 +1023,12 @@ mod tests {
             [languages.python]
             use-for = ["*.star", "*.py2"]
             language-server = [ "custom-language-server", "with-arg" ]
+            ignore-query = '(_) . (_)'
 
             [languages.some-custom-language]
             use-for = ["*.custom"]
             language-server = "custom-ls"
+            ignore-query = '(_) . (_)'
         "#};
         let parsed_manifest: Manifest = toml_edit::de::from_str(manifest_content).unwrap();
 
@@ -1079,6 +1081,13 @@ mod tests {
                 .collect::<Vec<_>>(),
             ["custom-language-server", "with-arg"],
         );
+        assert_eq!(
+            parsed_manifest.languages[&Language::Python]
+                .ignore_query
+                .as_ref()
+                .unwrap(),
+            "(_) . (_)"
+        );
         let custom_language = Language::External(Arc::from("some-custom-language"));
         assert_eq!(
             parsed_manifest.languages[&custom_language]
@@ -1094,6 +1103,13 @@ mod tests {
                 .parts()
                 .collect::<Vec<_>>(),
             ["custom-ls"],
+        );
+        assert_eq!(
+            parsed_manifest.languages[&custom_language]
+                .ignore_query
+                .as_ref()
+                .unwrap(),
+            "(_) . (_)"
         );
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -1204,7 +1204,7 @@ mod tests {
     #[test]
     fn load_custom_parser() {
         const PARSER_LINK: &str = "vexes/tree-sitter-lua";
-        VexTest::new("lua")
+        let run_data = VexTest::new("lua")
             .with_manifest(formatdoc! {r#"
                 [vex]
                 version = "1"
@@ -1232,11 +1232,17 @@ mod tests {
                     def on_match(event):
                         func = event.captures['func']
                         vex.warn('test-id', 'found a function', at=func)
-
-                        fail('oh no')
                 "#},
             )
-            .assert_irritation_free();
+            .with_source_file(
+                "main.lua",
+                indoc! {r#"
+                    print('hello')
+                "#},
+            )
+            .try_run()
+            .unwrap();
+        assert_eq!(run_data.irritations.len(), 1);
     }
 
     #[test]
@@ -1262,10 +1268,8 @@ mod tests {
                             '''
                                 (function_call) @func
                             ''',
-                            on_match,
+                            lambda x: x,
                         )
-
-                    def on_match(event):
                         fail('oh no')
                 "#},
             )

--- a/src/context.rs
+++ b/src/context.rs
@@ -729,7 +729,9 @@ impl LanguageData {
     }
 
     fn guess_raw_ignore_query(ts_language: &TSLanguage) -> Option<String> {
-        let mut comment_node_kinds = BTreeSet::new();
+        const KNOWN_COMMENT_MARKERS: [&str; 2] = ["comment", "line_comment"];
+
+        let mut comment_node_kinds = Vec::with_capacity(KNOWN_COMMENT_MARKERS.len());
         for id in 0..(ts_language.node_kind_count() as u16) {
             if !ts_language.node_kind_is_visible(id) || !ts_language.node_kind_is_named(id) {
                 continue;
@@ -738,11 +740,14 @@ impl LanguageData {
                 Some(nk) => nk,
                 None => continue,
             };
-            if !node_kind.ends_with("comment") {
+
+            if !KNOWN_COMMENT_MARKERS.contains(&node_kind) {
                 continue;
             }
-
-            comment_node_kinds.insert(node_kind);
+            if comment_node_kinds.contains(&node_kind) {
+                continue;
+            }
+            comment_node_kinds.push(node_kind);
         }
 
         if comment_node_kinds.is_empty() {

--- a/src/context.rs
+++ b/src/context.rs
@@ -1245,7 +1245,7 @@ mod tests {
 
     #[test]
     fn load_missing_parser() {
-        VexTest::new("lua")
+        VexTest::new("brainfuck")
             .with_manifest(indoc! {r#"
                 [vex]
                 version = "1"

--- a/src/context.rs
+++ b/src/context.rs
@@ -11,7 +11,7 @@ use tree_sitter::Language as TSLanguage;
 use tree_sitter_loader::{CompileConfig, Loader};
 
 use std::borrow::{Borrow, Cow};
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, HashMap};
 use std::fmt::Write as _;
 use std::io::{BufWriter, ErrorKind, Read, Write as _};
 use std::ops::Deref;
@@ -675,13 +675,7 @@ impl LanguageData {
                 "#}));
                 (ts_language, raw_ignore_query)
             }
-            Language::External(ref language_name) => {
-                let LanguageOptions { parser_dir, .. } = language_options;
-                let parser_dir = parser_dir.as_ref().ok_or_else(|| Error::ExternalLanguage {
-                    language: language.dupe(),
-                    cause: ExternalLanguageError::MissingParserDir,
-                })?;
-
+            Language::External(_) => {
                 let ts_language =
                     Self::load_ts_language(&language, language_options, project_root)?;
                 let raw_ignore_query = language_options
@@ -1178,7 +1172,6 @@ mod tests {
     #[test]
     fn load_custom_parser() {
         const PARSER_LINK: &str = "vexes/tree-sitter-lua";
-
         VexTest::new("lua")
             .with_manifest(formatdoc! {r#"
                 [vex]

--- a/src/error.rs
+++ b/src/error.rs
@@ -294,15 +294,15 @@ pub enum InvalidIgnoreQueryReason {
     #[display(fmt = "query captured nothing")]
     CapturedNothing,
 
-    #[display(fmt = "query did not capture 'vex:ignore'")]
-    CapturedTextExcludesIgnoreMarker,
+    #[display(fmt = "query did not capture 'vex:ignore' marker at {path}:{location}")]
+    CapturedTextExcludesIgnoreMarker {
+        path: PrettyPath,
+        location: Location,
+    },
 
     #[display(fmt = "{_0}")]
     General(Box<Error>),
 
-    #[display(fmt = "missing capture '{_0}' group")]
+    #[display(fmt = "missing capture group '{_0}'")]
     MissingCaptureGroup(&'static str),
-
-    #[display(fmt = "vex:ignore not present in match at {location}")]
-    NoIgnoreMarkerFound { location: Location },
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -47,6 +47,12 @@ pub enum Error {
     #[error(transparent)]
     FromPathBuf(#[from] camino::FromPathBufError),
 
+    #[error("cannot load {language} parser: {cause}")]
+    InaccessibleParserFiles {
+        language: Language,
+        cause: anyhow::Error,
+    },
+
     #[error("invalid ID '{raw_id}': {reason}")]
     InvalidID {
         raw_id: String,

--- a/src/error.rs
+++ b/src/error.rs
@@ -69,6 +69,9 @@ pub enum Error {
         reason: InvalidLoadReason,
     },
 
+    #[error("invalid ignore query: {0}")]
+    InvalidIgnoreQuery(InvalidIgnoreQueryReason),
+
     #[error("test invalid: {0}")]
     InvalidTest(String),
 
@@ -284,4 +287,22 @@ pub enum InvalidLoadReason {
 
     #[display(fmt = "load path invalid, see docs")] // TODO(kcza): link to spec once public.
     NonSpecific,
+}
+
+#[derive(Debug, Display)]
+pub enum InvalidIgnoreQueryReason {
+    #[display(fmt = "query captured nothing")]
+    CapturedNothing,
+
+    #[display(fmt = "query did not capture 'vex:ignore'")]
+    CapturedTextExcludesIgnoreMarker,
+
+    #[display(fmt = "{_0}")]
+    General(Box<Error>),
+
+    #[display(fmt = "missing capture '{_0}' group")]
+    MissingCaptureGroup(&'static str),
+
+    #[display(fmt = "vex:ignore not present in match at {location}")]
+    NoIgnoreMarkerFound { location: Location },
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -192,8 +192,11 @@ impl From<starlark::Error> for Error {
 
 #[derive(Debug, thiserror::Error)]
 pub enum ExternalLanguageError {
-    #[error("manifest language info missing `parser-dir` field")]
+    #[error("manifest info missing `parser-dir` field")]
     MissingParserDir,
+
+    #[error("manifest has no [language.{0}] table")]
+    NoConfig(Language),
 }
 
 #[derive(Debug, Display)]

--- a/src/language.rs
+++ b/src/language.rs
@@ -31,6 +31,10 @@ impl Language {
     pub fn is_builtin(&self) -> bool {
         !matches!(self, Self::External(_))
     }
+
+    pub fn is_external(&self) -> bool {
+        matches!(self, Self::External(_))
+    }
 }
 
 impl FromStr for Language {
@@ -100,10 +104,12 @@ mod tests {
 
             pub fn considered_builtin(self) {
                 assert!(self.language.is_builtin());
+                assert!(!self.language.is_external());
             }
 
             pub fn considered_not_builtin(self) {
                 assert!(!self.language.is_builtin());
+                assert!(self.language.is_external());
             }
         }
     }

--- a/src/source_file.rs
+++ b/src/source_file.rs
@@ -10,7 +10,7 @@ use walkdir::WalkDir;
 use crate::{
     cli::MaxConcurrentFileLimit,
     context::{Context, LanguageData, Manifest},
-    error::{Error, IOAction},
+    error::{Error, IOAction, InvalidIgnoreQueryReason},
     ignore_markers::{IgnoreMarkers, LintIdFilter},
     language::Language,
     result::{RecoverableResult, Result},
@@ -218,10 +218,12 @@ impl ParsedSourceFile {
 
         let mut builder = IgnoreMarkers::builder();
 
-        let marker_index = ignore_query
-            .capture_index_for_name("marker")
-            .expect("internal error: ignore query contains no 'marker' capture")
-            as usize;
+        let marker_index =
+            ignore_query
+                .capture_index_for_name("marker")
+                .ok_or(Error::InvalidIgnoreQuery(
+                    InvalidIgnoreQueryReason::MissingCaptureGroup("marker"),
+                ))? as usize;
         QueryCursor::new()
             .matches(ignore_query, self.tree.root_node(), self.content.as_bytes())
             .map(|qmatch| qmatch.captures)
@@ -242,12 +244,16 @@ impl ParsedSourceFile {
                         .iter()
                         .map(|qcap| qcap.node.byte_range().start)
                         .min()
-                        .expect("internal error: ignore query captured nothing");
+                        .ok_or(Error::InvalidIgnoreQuery(
+                            InvalidIgnoreQueryReason::CapturedNothing,
+                        ))?;
                     let end = qcaps
                         .iter()
                         .map(|qcap| qcap.node.byte_range().end)
                         .max()
-                        .expect("internal error: ignore query captured nothing");
+                        .ok_or(Error::InvalidIgnoreQuery(
+                            InvalidIgnoreQueryReason::CapturedNothing,
+                        ))?;
                     start..end
                 };
                 let filter = {
@@ -255,10 +261,13 @@ impl ParsedSourceFile {
 
                     let node = qcaps[marker_index].node;
                     let raw_text = node.utf8_text(self.content.as_bytes()).unwrap();
-                    let ids_start_index = raw_text
-                        .find(IGNORE_MARKER)
-                        .expect("vex:ignore not present in ignore marker")
-                        + IGNORE_MARKER.len();
+                    let ids_start_index =
+                        raw_text
+                            .find(IGNORE_MARKER)
+                            .ok_or(Error::InvalidIgnoreQuery(
+                                InvalidIgnoreQueryReason::CapturedTextExcludesIgnoreMarker,
+                            ))?
+                            + IGNORE_MARKER.len();
                     let raw_parts = raw_text[ids_start_index..]
                         .split(',')
                         .map(|raw_part| raw_part.trim());

--- a/src/vextest.rs
+++ b/src/vextest.rs
@@ -10,8 +10,6 @@ use std::{
 #[cfg(unix)]
 use std::os::unix;
 #[cfg(windows)]
-use std::os::windows;
-#[cfg(windows)]
 use std::process::Command;
 
 use camino::{Utf8Component, Utf8PathBuf};

--- a/src/vextest.rs
+++ b/src/vextest.rs
@@ -4,12 +4,15 @@ use std::{
     env,
     fs::{self, File},
     io::Write,
+    path,
 };
 
 #[cfg(unix)]
 use std::os::unix;
 #[cfg(windows)]
 use std::os::windows;
+#[cfg(windows)]
+use std::process::Command;
 
 use camino::{Utf8Component, Utf8PathBuf};
 use indoc::indoc;
@@ -182,7 +185,7 @@ impl<'s> VexTest<'s> {
                 parser_dir,
                 link_file,
             } = parser_dir_link;
-            let parser_dir = parser_dir.canonicalize_utf8().unwrap();
+            let parser_dir = Utf8PathBuf::try_from(path::absolute(parser_dir).unwrap()).unwrap();
             let link_file = root_path.join(link_file);
 
             if let Some(parent) = link_file.parent() {
@@ -196,7 +199,22 @@ impl<'s> VexTest<'s> {
             }
             #[cfg(windows)]
             {
-                windows::fs::symlink_dir(parser_dir, link_file).unwrap();
+                // Ugly workaround because on Windows, symlinks require admin permissions to create. Amazing.
+                let parser_dir: Utf8PathBuf = parser_dir.components().collect(); // Sanitise separators.
+                let link_file: Utf8PathBuf = link_file.components().collect(); // Sanitise separators.
+                let stderr = Command::new("cmd")
+                    .arg("/C")
+                    .arg("mklink")
+                    .arg("/J")
+                    .arg(link_file)
+                    .arg(parser_dir)
+                    .output()
+                    .unwrap()
+                    .stderr;
+                let stderr = String::from_utf8_lossy(&stderr);
+                if !stderr.trim().is_empty() {
+                    eprint!("{stderr:?}");
+                }
                 continue;
             }
             #[allow(unreachable_code)]


### PR DESCRIPTION
This PR allows `vex` to guess the ignore query of a requested tree-sitter grammar by looking for nodes named `comment` or `line_comment`. This is intended to cover all reasonable language; if a future language is found for which this does not hold, an issue should be raised.

In the case that an ignore query cannot be guessed, or if the guessed ignore query is incorrect, the user may provide their own with the new `language.<lang>.ignore-query` manifest key
